### PR TITLE
Fixed container command in op-scim-deployment.yaml

### DIFF
--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: op-scim
         image: 1password/scim:v0.5.8
-        command: ["./op-scim"]
+        command: ["/op-scim/op-scim"]
         args: ["--session=/secret/scimsession", "--letsencrypt-domain={YOUR-DOMAIN-HERE}"]
         ports:
         - containerPort: 3002


### PR DESCRIPTION
When attempting to deploy op-scim, I received the following error:

```
    Last State:  Terminated
      Reason:    ContainerCannotRun
      Message:   oci runtime error: container_linux.go:247: starting container process caused "exec: \"./op-scim\": permission denied"
```

Changing the container command from ./op-scim to /op-scim/op-scim, as in the Docker compose file, fixed the issue.