### PR TITLE
[FIXED] switched to specfic version numbers for setup script

### DIFF
--- a/scim-setup.bat
+++ b/scim-setup.bat
@@ -2,7 +2,7 @@
 
 md session
 
-docker run -it -v "%CD%\session":"/op-scim/session" 1password/scim:latest /op-scim/create-session-docker.sh
+docker run -it -v "%CD%\session":"/op-scim/session" 1password/scim:v0.7 /op-scim/create-session-docker.sh
 
 move .\session\scimsession .\
 rd session

--- a/scim-setup.sh
+++ b/scim-setup.sh
@@ -2,7 +2,7 @@
 
 mkdir session
 
-docker run -it -v $PWD/session:'/op-scim/session' 1password/scim:latest /op-scim/create-session-docker.sh
+docker run -it -v $PWD/session:'/op-scim/session' 1password/scim:v0.7 /op-scim/create-session-docker.sh
 
 cp ./session/scimsession ./scimsession
 rm -rf ./session


### PR DESCRIPTION
This fixes an issue where anyone who ran the setup script pre-0.7 would not get the latest image pulled, so they would get the old setup tool.