### PR TITLE
Add section to Terraform README about region env var

### DIFF
--- a/aws-terraform/README.md
+++ b/aws-terraform/README.md
@@ -54,11 +54,11 @@ Below is the overall code structure of the Terraform deployment.
 
 ## Deploying using Terraform
 
-0. Set the environment variable for your AWS/Terraform deployment’s region by exporting the following environment variable:
+0. If you don’t have a region set through your `aws` command line tools, you’ll want to have an environment variable to the region your preferred region. This can solve errors such as `The argument "region" is required, but was not set.`
 
 ```bash
-# for example: export AWS_DEFAULT_REGION=”us-east-2”
-export AWS_DEFAULT_REGION=”<aws_region>”
+# change “aws-region-x” to your preferred region, for example: export AWS_DEFAULT_REGION=”us-east-2”
+export AWS_DEFAULT_REGION=”aws-region-x”
 ```
 
 1. Copy `deploy/example_env` to a new directory depending on the environment you wish to deploy to. (e.g: `testing`, `production`, etc)

--- a/aws-terraform/README.md
+++ b/aws-terraform/README.md
@@ -54,6 +54,13 @@ Below is the overall code structure of the Terraform deployment.
 
 ## Deploying using Terraform
 
+0. Set the environment variable for your AWS/Terraform deployment’s region by exporting the following environment variable:
+
+```bash
+# for example: export AWS_DEFAULT_REGION=”us-east-2”
+export AWS_DEFAULT_REGION=”<aws_region>”
+```
+
 1. Copy `deploy/example_env` to a new directory depending on the environment you wish to deploy to. (e.g: `testing`, `production`, etc)
 
 Example:


### PR DESCRIPTION
See: https://github.com/terraform-providers/terraform-provider-aws/issues/9989

If someone doesn't have an `~/.aws/config` file, then this environment variable is necessary. To prevent confusion we should just have them set it to whatever region they want to use.