### PR TITLE
Kubernetes simplification expansion/bugfixes

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,24 +1,26 @@
 # Deploying the 1Password SCIM Bridge on Kubernetes
 
-This example explains how to deploy the 1Password SCIM bridge on a Kubernetes cluster. It assumes your kubernetes cluster supports "load-balancer" services.
+This example explains how to deploy the 1Password SCIM bridge on a Kubernetes cluster. It assumes your Kubernetes cluster supports "load balancer" services.
+
+You can modify this deployment to suit your environment and needs.
 
 If you are deploying to the Azure Kubernetes Service, you can refer to our [detailed deployment guide instead](https://support.1password.com/cs/scim-deploy-azure/).
 
 The deployment process consists of these steps:
 
 1. Create the scimsession Kubernetes secret
-2. Configure the SCIM bridge (through the `op-scim-deployment.yaml`) file
-3. Deploy the manifests
-4. Set up DNS entries for let's encrypt
+2. Configure the SCIM bridge (through the `op-scim-config.yaml`) file
+3. Deploy the service
+4. Set up DNS entries for LetsEncrypt
 
 ## Structure
 
-- `op-scim-deployment.yaml`: The SCIM bridge deployment. See the command line options configuratble
-- `op-scim-service.yaml`: The public load-balancer for the service 
-- `redis-deployment.yaml`:  [(optional*)](#optional-redis) A redis server deployment. 
-- `redis-service.yaml`:  [(optional*)](#optional-redis) Kubernetes service for the redis deployment. Referenced by `op-scim` app.
+- `op-scim-deployment.yaml`: The SCIM Bridge deployment.
+- `op-scim-service.yaml`: Public load balancer for the SCIM Bridge server.
+- `op-scim-config.yaml`: Configuration for the SCIM Bridge server. You’ll be modifying this file during the deployment.
+- `redis-deployment.yaml`:  [(optional*)](#external-redis-server) A redis server deployment.
+- `redis-service.yaml`:  [(optional*)](#external-redis-server) Kubernetes service for the redis deployment.
 
-_<a name="optional-redis"></a>* A redis instance is required when using the SCIM Bridge. You can use your own already existing redis instances. This is configurable through the `--redis-host` and `--redis-port` command line flags._
 
 ## Preparing
 
@@ -26,37 +28,47 @@ Please ensure you've read through the [PREPARATION.md](/PREPARATION.md) document
 
 ### Create the `scimsession` Kubernetes secret
 
-Next, we must create a Kubernetes secret containing the scimsession file. Using `kubectl`, we can read the scimsession file and create the secret in one command:
+The following requires that you’ve completed the initial setup of Provisioning in your 1Password Account. [See here](https://support.1password.com/scim/#step-1-prepare-your-1password-account) for more details.
 
-```
-kubectl create secret generic scimsession --from-file=./scimsession
-```
+Once complete, you must create a Kubernetes secret containing the `scimsession` file. Using `kubectl`, we can read the `scimsession` file and create the Kubernetes secret in one command:
 
-Make sure to pass the filepath of the scimsession file that you downloaded.  The above command will look for the file in this folder (the `/kubernetes/` folder) of the repository.
+```bash
+kubectl create secret generic scimsession --from-file=/path/to/scimsession
+```
 
 
 ### Configuring the SCIM bridge
 
-You'll want to edit the `op-scim-deployment.yaml` file and change the variable `{YOUR-DOMAIN-HERE}` to the domain you've decided on. This allows LetsEncrypt to issue your deployment an SSL certificate necessary for encrypted traffic. 
+You'll need to edit the `op-scim-config.yaml` file and change the variable `OP_LETSENCRYPT_DOMAIN` to the domain you've decided on for your SCIM Bridge. This allows LetsEncrypt to issue your deployment an SSL certificate necessary for encrypted traffic.
 
 
-## Deploy to the kubernetes cluster
+## Deploy to the Kubernetes cluster
 
-```sh
+Run the following `kubectl` command to complete your deployment. It will deploy the both the `redis` server and the `op-scim` app.
+
+```bash
 kubectl apply -f .
 ```
 
 
 ## Configure the DNS entries
 
-The Kubernetes deployment creates a public load balancer in your environment pointing to the SCIM Bridge. To get its address use: `kubectl describe service/op-scim`. It can take some time before the public address becomes available.
+The Kubernetes deployment creates a public load balancer in your environment pointing to the SCIM Bridge.
 
-At this stage, you can finish configuring your DNS entry as outlined in [PREPARATION.md](/PREPARATION.md). 
+To get its public IP address:
+
+```bash
+kubectl describe service/op-scim
+```
+
+It can take some time before the public address becomes available.
+
+At this stage, you can finish configuring your DNS entry as outlined in [PREPARATION.md](/PREPARATION.md).
 
 
 ## Test the instance
 
-Once the DNS record has propagated, you can test your instance by requesting `https://[your-domain]/scim/Users`, with the header `Authorization: Bearer [bearer token]` which should return a list of the users in your 1Password account. 
+Once the DNS record has propagated, you can test your instance by requesting `https://[your-domain]/scim/Users`, with the header `Authorization: Bearer [bearer token]` which should return a list of the users in your 1Password account.
 
 You can do this with `curl`, as an example:
 
@@ -64,6 +76,19 @@ You can do this with `curl`, as an example:
 curl --header "Authorization: Bearer <bearertoken>" https://<domain>/scim/Users
 ```
 
-Alternatively, you can visit the domain in any web browser. You'll see a 1Password SCIM Bridge Status page which can be used to verify your OAuth bearer token. This page is being served by your SCIM Bridge using a secured TLS connection established using your LetsEncrypt domain certificate.
-
 You can now continue with the administration guide to configure your Identity Provider to enable provisioning with your SCIM Bridge.
+
+
+## Advanced deployments
+
+The following are helpful tips in case you wish to perform an advanced deployment.
+
+### External load balancer
+
+In `op-scim-config.yaml`, you can set the `OP_LETSENCRYPT_DOMAIN` variable to blank, which will have the SCIM Bridge serve on port 3002. You can then map your pre-existing webserver (Apache, NGINX, etc). You will no longer be issued a certificate by LetsEncrypt.
+
+### External redis server
+
+If you are using an existing redis instance that's not running on `redis:6379`, you can change the `OP_REDIS_HOST` and `OP_REDIS_PORT` variables in `op-scim-config.yaml`.
+
+You would then omit the the `redis-*.yaml` files when deploying to your Kubernetes cluster.

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -4,8 +4,8 @@ metadata:
   name: op-scim-configmap
 data:
   # set this to the URL you've selected for your SCIM Bridge deployment
-  OP_LETSENCRYPT_DOMAIN: "op-scim.example.com"
+  OP_LETSENCRYPT_DOMAIN: ""
   # (advanced) only change the options below if you need to
-  OP_REDIS_HOST: "redis"
+  OP_REDIS_HOST: "op-scim-redis"
   OP_REDIS_PORT: "6379"
   OP_SESSION: "/secret/scimsession"

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: op-scim-config
+  name: op-scim-configmap
 data:
   # set this to the URL you've selected for your SCIM Bridge deployment
-  OP_LETSENCRYPT_DOMAIN: op-scim.example.com
+  OP_LETSENCRYPT_DOMAIN: "op-scim.example.com"
   # (advanced) only change the options below if you need to
-  OP_REDIS_HOST: redis
-  OP_REDIS_PORT: 6379
-  OP_SESSION: /secret/scimsession
+  OP_REDIS_HOST: "redis"
+  OP_REDIS_PORT: "6379"
+  OP_SESSION: "/secret/scimsession"

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: op-scim-config
+data:
+  # set this to the URL you've selected for your SCIM Bridge deployment
+  OP_LETSENCRYPT_DOMAIN: op-scim.example.com
+  # (advanced) only change the options below if you need to
+  OP_REDIS_HOST: redis
+  OP_REDIS_PORT: 6379
+  OP_SESSION: /secret/scimsession

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -16,11 +16,6 @@ spec:
       - name: op-scim
         image: 1password/scim:v1.6.0
         command: ["/op-scim/op-scim"]
-        args:
-        - "--session=/secret/scimsession"
-        - "--letsencrypt-domain={YOUR-DOMAIN-HERE}"
-        - "--redis-host=redis
-        - "--redis-port=6379"
         livelinessProbe:
           httpGet:
             path: /ping
@@ -30,13 +25,14 @@ spec:
         ports:
         - containerPort: 8443
         - containerPort: 8080
+        - containerPort: 3002
         volumeMounts:
         - name: scimsession
           mountPath: "/secret"
           readOnly: false
-        env:
-        - name: update
-          value: "2"
+        envFrom:
+          - configMapRef:
+            name: op-scim-config
       volumes:
       - name: scimsession
         secret:

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -1,38 +1,38 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: op-scim
+  name: op-scim-bridge
 spec:
   selector:
     matchLabels:
-      app: op-scim
+      app: op-scim-bridge
   replicas: 1
   template:
     metadata:
       labels:
-        app: op-scim
+        app: op-scim-bridge
     spec:
       containers:
       - name: op-scim
         image: 1password/scim:v1.6.0
         command: ["/op-scim/op-scim"]
-        livelinessProbe:
+        livenessProbe:
           httpGet:
             path: /ping
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3
         ports:
+        - containerPort: 3002
         - containerPort: 8443
         - containerPort: 8080
-        - containerPort: 3002
         volumeMounts:
         - name: scimsession
           mountPath: "/secret"
           readOnly: false
         envFrom:
           - configMapRef:
-            name: op-scim-config
+              name: op-scim-configmap
       volumes:
       - name: scimsession
         secret:

--- a/kubernetes/op-scim-service.yaml
+++ b/kubernetes/op-scim-service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: op-scim
+  name: op-scim-bridge
   labels:
-    app: op-scim
+    app: op-scim-bridge
 spec:
   type: LoadBalancer
   # Traffic on :80 is needed for the status page and to perform the 

--- a/kubernetes/op-scim-service.yaml
+++ b/kubernetes/op-scim-service.yaml
@@ -6,14 +6,14 @@ metadata:
     app: op-scim
 spec:
   type: LoadBalancer
+  # Traffic on :80 is needed for the status page and to perform the 
+  # LetsEncrypt certificate challenges after which all SCIM traffic
+  # will be served on :443.
   ports:
   - protocol: TCP
     name: https
     port: 443
     targetPort: 8443
-# Traffic on :80 is needed for the status page and to perform the 
-# LetsEncrypt certificate challenges after which all SCIM traffic
-# will be served on :443.
   - protocol: TCP
     name: http
     port: 80


### PR DESCRIPTION
Expanding upon #117.

There were a few issues with that PR that needed to be fixed:
* `redis` no longer a valid hostname for redis server as name has changed to `op-scim-redis`
* `livelinessProbe` -> `livenessProbe` (typo)
* Missing quote in `args`
* Re-added port 3002 option and supporting documentation as it comes up enough for users that I think it's an important addition
* A few typos in the README.md

I've also made the following changes:
* Moved the `args` to their own config file at `op-scim-config.yaml` using `ConfigMap`. This makes the available options for users more apparent, and bring it in line with the Docker deployment (which uses `scim.env`)