### PR TITLE
Fix targetPort to containerPort deployment

### DIFF
--- a/kubernetes/op-scim-service.yaml
+++ b/kubernetes/op-scim-service.yaml
@@ -13,10 +13,10 @@ spec:
   - protocol: TCP
     name: https
     port: 443
-    targetPort: 8443
+    targetPort: 3002
   - protocol: TCP
     name: http
     port: 80
-    targetPort: 8080
+    targetPort: 3002
   selector:
     app: op-scim-bridge


### PR DESCRIPTION
As the deployment uses the containerPort `3002`, this PR fixes the `targetPort` service.