### PR TITLE
`restart: always` in Docker Swarm example.

### DIFF
--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: on-failure
+        condition: always
     networks:
       - op-scim
     ports:
@@ -24,7 +24,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: on-failure
+        condition: always
     networks:
       - op-scim
 


### PR DESCRIPTION
Fixes another issue with Docker Swarm not restarting containers on reboot.