### PR TITLE
Bump to v2.2.0

### DIFF
--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "scim-bridge",
-    "image": "1password/scim:v2.1.2",
+    "image": "1password/scim:v2.2.0",
     "cpu": 128,
     "memory": 512,
     "essential": true,

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   scim:
-    image: 1password/scim:v2.1.2
+    image: 1password/scim:v2.2.0
     ports:
       - "3002:3002"
       - "80:8080"

--- a/docker/compose/scim.env
+++ b/docker/compose/scim.env
@@ -25,3 +25,6 @@ OP_REDIS_URL=redis://redis:6379
 
 # OP_DEBUG enables more detailed logging, which can be useful during troubleshooting or debugging
 #OP_DEBUG=1
+
+# OP_LETSENCRYPT_EMAIL changes the email address provided to Let's Encrypt when a certificate is issued for your SCIM bridge, default: "1pw@[OP_LETSENCRYPT_DOMAIN]"
+#OP_LETSENCRYPT_EMAIL=scim@example.com

--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   scim:
-    image: 1password/scim:v2.1.2
+    image: 1password/scim:v2.2.0
     deploy:
       replicas: 1
       restart_policy:

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -10,3 +10,6 @@ data:
   OP_SESSION: "/secret/scimsession"
   OP_PRETTY_LOGS: "0"
   OP_DEBUG: "0"
+  # (optional) uncomment this line to change the email that is used when Let's Encrypt issues your SCIM bridge a certificate
+  # default: "1pw@[OP_LETSENCRYPT_DOMAIN]" 
+  #OP_LETSENRYPT_EMAIL: "1pw@example.com"

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: op-scim-bridge
-          image: 1password/scim:v2.1.2
+          image: 1password/scim:v2.2.0
           ports:
             - containerPort: 3002
           volumeMounts:


### PR DESCRIPTION
Bumps SCIM bridge to version 2.2.0.

Also adds `OP_LETSENCRYPT_EMAIL`, a configurable field within the new Let's Encrypt library.