### PR TITLE
Allow 307 return code

### DIFF
--- a/aws-ecsfargate-terraform/terraform.tf
+++ b/aws-ecsfargate-terraform/terraform.tf
@@ -168,7 +168,7 @@ resource "aws_lb_target_group" "target_group_http" {
   target_type = "ip"
   vpc_id      = data.aws_vpc.default.id
   health_check {
-    matcher = "200,301,302"
+    matcher = "200,301,302,307"
     path    = "/"
   }
 }


### PR DESCRIPTION
When deployed the Redis container keeps crashing given that the services cannot get a healthy check, allowing 307 fixes this.