### PR TITLE
Update health check path to /app to avoid 307 redirect

### DIFF
--- a/aws-ecsfargate-terraform/terraform.tf
+++ b/aws-ecsfargate-terraform/terraform.tf
@@ -169,7 +169,7 @@ resource "aws_lb_target_group" "target_group_http" {
   vpc_id      = data.aws_vpc.default.id
   health_check {
     matcher = "200,301,302"
-    path    = "/"
+    path    = "/app"
   }
 }
 


### PR DESCRIPTION
Because of a `307 Temporary Redirect` response code being returned from `/`, configs using `/` as the health check are continually failing and recreating the ECS task, resulting in broken bridges.

Prior to release `v2.3.0` of the SCIM bridge, hitting `GET /` would return a `200` if everything was healthy, and therefore was a proper path for health checks. Now with `v2.3.0` we are redirecting `/` to `/app` in order to serve the new React app, so defining `/app` as the health check path by default gets us to a working state.

Since release `v2.3.0`, users can also enable an optional ping server on `/ping` for health check purposes. This will be the way forward as the default for our helm charts, but this requires the `OP_PING_SERVER` option to be enabled, so for this ECS Fargate terraform config we'll need to keep it as `/app`. 