### PR TITLE
Update Terraform example README.md

### DIFF
--- a/aws-ecsfargate-terraform/README.md
+++ b/aws-ecsfargate-terraform/README.md
@@ -91,9 +91,9 @@ After a few minutes and the DNS update has had time to take effect, go to the SC
 
 Connect to your Identity Provider following [the remainder of our setup guide](https://support.1password.com/scim/#step-2-deploy-the-scim-bridge).
 
-## Upgrading
+## Updating
 
-To upgrade your deployment, edit the `task-definitions/scim.json` file and edit the following line:
+To update your deployment to the latest version, edit the `task-definitions/scim.json` file and edit the following line:
 
 ```json
     "image": "1password/scim:v2.0.x",
@@ -107,6 +107,10 @@ Then, reapply your Terraform settings:
 terraform plan -out=./op-scim.plan
 terraform apply ./op-scim.plan
 ```
+
+### December 2021 Update Changes
+
+As of December 2021, [the ALB health check path has changed](https://github.com/1Password/scim-examples/pull/162). If you are updating from a version earlier than 2.3.0, edit your `terraform.tf` file [to use `/app` instead of `/`](https://github.com/1Password/scim-examples/pull/162/commits/a876c46b9812e96f65e42e0441a772566ca32176#) for the health check before reapplying your Terraform settings.
 
 ## Troubleshooting
 


### PR DESCRIPTION
A recent PR (https://github.com/1Password/scim-examples/pull/162) fixed deployment failures for _new_ AWS deployments, but the problem persists for anyone updating to 2.3.0 from an earlier version who isn’t aware of the change to the health check path in the Terraform script.

This PR includes the following changes to the `README` for this deployment example:
- I added a section in the update instructions for updating from versions older than 2.3.0 so the health check will pass.
- I also changed `upgrade` to `update` for consistency with our support articles (i.e. [Update the 1Password SCIM bridge](https://support.1password.com/scim-update/)).