### PR TITLE
Map port 3002 in Docker Swarm YAML

### DIFF
--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     ports:
       - "80:8080"
       - "443:8443"
+      - "3002:3002"
     secrets:
       - source: scimsession
         target: scimsession


### PR DESCRIPTION
This PR is a quick fix to the Docker Swarm deployment example; it was missing a port mapping to listen for unencrypted traffic when deployed behind a load balancer or proxy.