### PR TITLE
Fix Terraform example security group

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -195,6 +195,8 @@ resource "aws_security_group" "alb" {
 }
 
 resource "aws_security_group" "service" {
+  # Create a security group for the service
+  vpc_id = data.aws_vpc.this.id
   
   # Only allow traffic from the load balancer security group
   ingress {


### PR DESCRIPTION
This PR fixes a deployment error encountered in certain scenarios.

Without explicitly specifying the `vpc_id` for the `aws_security_group.service` resource, this security group does not necessarily get created in the same VPC as the `aws_security_group.alb` security group.

If the security groups are not created in the same VPC, applying the plan errors and halts, because they are expected to be in the same VPC. 😅

Specifying the VPC from the `aws_vpc` data resource resolves the issue. I also added a comment for consistency with the `aws_security_group.alb` resource.