### PR TITLE
ht-6658_remove_secret

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = ">= 0.14.0"
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -9,17 +7,13 @@ terraform {
   }
 }
 
-provider "aws" {
-  region = var.aws_region
-}
-
 locals {
   name_prefix = var.name_prefix != "" ? var.name_prefix : "op-scim-bridge"
   domain      = join(".", slice(split(".", var.domain_name), 1, length(split(".", var.domain_name))))
-  tags        = merge(var.tags, {
-                  application = "1Password SCIM Bridge",
-                  version     = trimprefix(jsondecode(file("task-definitions/scim.json"))[0].image, "1password/scim:v")
-                })
+  tags = merge(var.tags, {
+    application = "1Password SCIM Bridge",
+    version     = trimprefix(jsondecode(file("task-definitions/scim.json"))[0].image, "1password/scim:v")
+  })
 }
 
 data "aws_vpc" "this" {
@@ -31,7 +25,10 @@ data "aws_vpc" "this" {
 data "aws_subnet_ids" "public" {
   vpc_id = data.aws_vpc.this.id
   # Find the public subnets in the VPC
-  tags   = var.vpc_name != "" ? { SubnetTier = "public"} : {}
+  filter {
+    name   = "tag:Name"
+    values = [var.subnet_name]
+  }
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {
@@ -52,71 +49,58 @@ data "aws_iam_policy_document" "scimsession" {
     ]
 
     resources = [
-      aws_secretsmanager_secret.scimsession.arn,
+      var.scimsession_arn,
     ]
   }
 }
 
 data "aws_acm_certificate" "wildcard_cert" {
-  count  =  !var.wildcard_cert ? 0 : 1
+  count = ! var.wildcard_cert ? 0 : 1
 
   domain = "*.${local.domain}"
 }
 
 data "aws_route53_zone" "zone" {
-  count        = var.using_route53 ? 1 : 0
+  count = var.using_route53 ? 1 : 0
 
   name         = local.domain
   private_zone = false
 }
 
-resource "aws_secretsmanager_secret" "scimsession" {
-  name_prefix             = local.name_prefix
-  # Allow `terraform destroy` to delete secret (hint: save your scimsession file in 1Password)
-  recovery_window_in_days = 0
-
-  tags                    = local.tags
-}
-
-resource "aws_secretsmanager_secret_version" "scimsession_1" {
-  secret_id     = aws_secretsmanager_secret.scimsession.id
-  secret_string = base64encode(file("${path.module}/scimsession"))
-}
-
 resource "aws_cloudwatch_log_group" "op_scim_bridge" {
   name_prefix       = local.name_prefix
-  retention_in_days = var.log_retention_days 
-  
-  tags              = local.tags
+  retention_in_days = var.log_retention_days
+
+  tags = local.tags
 }
 
 resource "aws_ecs_cluster" "op_scim_bridge" {
-  name = var.name_prefix == "" ? "op-scim-bridge" : format("%s-%s",local.name_prefix,"scim-bridge")
+  name = var.name_prefix == "" ? "op-scim-bridge" : format("%s-%s", local.name_prefix, "scim-bridge")
 
   tags = local.tags
 }
 
 resource "aws_ecs_task_definition" "op_scim_bridge" {
-  family                   = var.name_prefix == "" ? "op_scim_bridge" : format("%s_%s",local.name_prefix,"scim_bridge")
-  container_definitions    = templatefile("task-definitions/scim.json",
-    { secret_arn     = aws_secretsmanager_secret.scimsession.arn,
+  family = var.name_prefix == "" ? "op_scim_bridge" : format("%s_%s", local.name_prefix, "scim_bridge")
+  container_definitions = templatefile("task-definitions/scim.json",
+    { secret_arn     = var.scimsession_arn,
       aws_logs_group = aws_cloudwatch_log_group.op_scim_bridge.name,
       region         = var.aws_region
   })
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  memory                   = 512
-  cpu                      = 256
+  memory                   = var.ecs_task_memory
+  cpu                      = var.ecs_task_cpu
   execution_role_arn       = aws_iam_role.op_scim_bridge.arn
 
-  tags                     = local.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role" "op_scim_bridge" {
-  name_prefix = local.name_prefix
+  name_prefix        = local.name_prefix
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 
-  tags               = local.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "op_scim_bridge" {
@@ -131,13 +115,13 @@ resource "aws_iam_role_policy" "scimsession" {
 }
 
 resource "aws_ecs_service" "op_scim_bridge" {
-  name             = format("%s_%s",local.name_prefix,"service")
+  name             = format("%s_%s", local.name_prefix, "service")
   cluster          = aws_ecs_cluster.op_scim_bridge.id
   task_definition  = aws_ecs_task_definition.op_scim_bridge.arn
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
   desired_count    = 1
-  
+
   load_balancer {
     target_group_arn = aws_lb_target_group.op_scim_bridge.arn
     container_name   = jsondecode(file("task-definitions/scim.json"))[0].name
@@ -147,77 +131,93 @@ resource "aws_ecs_service" "op_scim_bridge" {
   network_configuration {
     subnets          = data.aws_subnet_ids.public.ids
     assign_public_ip = true
-    security_groups  = [aws_security_group.service.id]
+    security_groups  = [aws_security_group.svc.id]
   }
 
-  tags             = local.tags
+  tags = local.tags
 
-  depends_on       = [aws_lb_listener.https]
+  depends_on = [aws_lb_listener.https]
 }
 
 resource "aws_alb" "op_scim_bridge" {
-  name               = var.name_prefix == "" ? "op-scim-bridge-alb" : format("%s-%s",local.name_prefix,"alb")
+  name               = var.name_prefix == "" ? "op-scim-bridge-alb" : format("%s-%s", local.name_prefix, "alb")
   load_balancer_type = "application"
   subnets            = data.aws_subnet_ids.public.ids
-  security_groups    = [aws_security_group.alb.id]
-  
-  tags               = local.tags
-}
-
-resource "aws_security_group" "alb" {
-  # Create a security group for the load balancer
-  vpc_id = data.aws_vpc.this.id
-
-  # Allow HTTP traffic from anywhere
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # Allow HTTPS traffic from anywhere
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags   = local.tags
-}
-
-resource "aws_security_group" "service" {
-  # Create a security group for the service
-  vpc_id = data.aws_vpc.this.id
-  
-  # Only allow traffic from the load balancer security group
-  ingress {
-    from_port = 3002
-    to_port   = 3002
-    protocol  = "tcp"
-    security_groups = [aws_security_group.alb.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  security_groups    = [aws_security_group.lb.id]
 
   tags = local.tags
 }
 
+resource "aws_security_group" "lb" {
+  # Create a security group for the load balancer
+  vpc_id = data.aws_vpc.this.id
+
+  tags = local.tags
+}
+
+resource "aws_security_group_rule" "inbound-443-alb" {
+  security_group_id = aws_security_group.lb.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "inbound-80-alb" {
+  security_group_id = aws_security_group.lb.id
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "outbound-3002-alb-service" {
+  security_group_id        = aws_security_group.lb.id
+  type                     = "egress"
+  from_port                = 3002
+  to_port                  = 3002
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.svc.id
+}
+
+resource "aws_security_group" "svc" {
+  # Create a security group for the service
+  vpc_id = data.aws_vpc.this.id
+
+  tags = local.tags
+}
+
+resource "aws_security_group_rule" "inbound-3002-alb-service" {
+  security_group_id        = aws_security_group.svc.id
+  type                     = "ingress"
+  from_port                = 3002
+  to_port                  = 3002
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.lb.id
+}
+
+resource "aws_security_group_rule" "outbound-443-service" {
+  security_group_id = aws_security_group.svc.id
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "outbound-80-service" {
+  security_group_id = aws_security_group.svc.id
+  type              = "egress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_lb_target_group" "op_scim_bridge" {
-  name        = var.name_prefix == "" ? "op-scim-bridge-tg" : format("%s-%s",local.name_prefix,"tg")
+  name        = var.name_prefix == "" ? "op-scim-bridge-tg" : format("%s-%s", local.name_prefix, "tg")
   port        = 3002
   protocol    = "HTTP"
   target_type = "ip"
@@ -227,25 +227,43 @@ resource "aws_lb_target_group" "op_scim_bridge" {
     path    = "/app"
   }
 
-  tags        = local.tags
+  tags = local.tags
 }
 
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_alb.op_scim_bridge.arn
   port              = 443
   protocol          = "HTTPS"
-  certificate_arn   = !var.wildcard_cert ? (
-                        var.using_route53 ?
-                          aws_acm_certificate_validation.op_scim_bridge[0].certificate_arn : aws_acm_certificate.op_scim_bridge[0].arn
-                        ) : data.aws_acm_certificate.wildcard_cert[0].arn
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn = ! var.wildcard_cert ? (
+    var.using_route53 ?
+    aws_acm_certificate_validation.op_scim_bridge[0].certificate_arn : aws_acm_certificate.op_scim_bridge[0].arn
+  ) : data.aws_acm_certificate.wildcard_cert[0].arn
+
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.op_scim_bridge.arn
   }
 }
 
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_alb.op_scim_bridge.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_acm_certificate" "op_scim_bridge" {
-  count             = !var.wildcard_cert ? 1 : 0
+  count = ! var.wildcard_cert ? 1 : 0
 
   domain_name       = var.domain_name
   validation_method = "DNS"
@@ -256,7 +274,7 @@ resource "aws_acm_certificate" "op_scim_bridge" {
 }
 
 resource "aws_acm_certificate_validation" "op_scim_bridge" {
-  count                   = var.using_route53 && !var.wildcard_cert ? 1 : 0
+  count = var.using_route53 && ! var.wildcard_cert ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.op_scim_bridge[0].arn
   validation_record_fqdns = [for record in aws_route53_record.op_scim_bridge_validation : record.fqdn]
@@ -265,7 +283,7 @@ resource "aws_acm_certificate_validation" "op_scim_bridge" {
 
 resource "aws_route53_record" "op_scim_bridge_validation" {
   for_each = (
-    var.using_route53 && !var.wildcard_cert ?
+    var.using_route53 && ! var.wildcard_cert ?
     {
       for dvo in aws_acm_certificate.op_scim_bridge[0].domain_validation_options : dvo.domain_name => {
         name   = dvo.resource_record_name
@@ -284,7 +302,7 @@ resource "aws_route53_record" "op_scim_bridge_validation" {
 }
 
 resource "aws_route53_record" "op_scim_bridge" {
-  count   = var.using_route53 ? 1 : 0
+  count = var.using_route53 ? 1 : 0
 
   zone_id = data.aws_route53_zone.zone[0].id
   name    = var.domain_name

--- a/aws-ecsfargate-terraform/variables.tf
+++ b/aws-ecsfargate-terraform/variables.tf
@@ -1,8 +1,3 @@
-variable "aws_region" {
-  type        = string
-  description = "The region of the AWS account where the 1Password SCIM bridge will be deployed."
-}
-
 variable "domain_name" {
   type        = string
   description = "The public DNS address pointing to your SCIM bridge."
@@ -11,6 +6,7 @@ variable "domain_name" {
 variable "tags" {
   type        = map(string)
   description = "A set of tags to apply to all respective AWS resources."
+  default     = {}
 }
 
 variable "name_prefix" {
@@ -38,4 +34,26 @@ variable "using_route53" {
 variable "log_retention_days" {
   type        = number
   description = "Specifies the number of days to retain log events in CloudWatch. Set to the default of 0, the log is retained indefinitely."
+}
+
+variable "scimsession_arn" {
+  type        = string
+  description = "ARN of the secret storing the scimsession file."
+}
+
+variable "subnet_name" {
+  type        = string
+  description = "Regular expression for the Name tag to search for subnet ids."
+}
+
+variable "ecs_task_memory" {
+  type        = number
+  description = "Memory value to set in the task definition."
+  default     = 512
+}
+
+variable "ecs_task_cpu" {
+  type        = number
+  description = "CPU value to set in the task definition."
+  default     = 256
 }


### PR DESCRIPTION
## jira:
* [HT-6658](https://humnai.atlassian.net/browse/HT-6658)
## motivation:
* Reuse 1password's ECS Fargate deployment
## changes:
* Remove secret from code has it is kept in Terraform state
* Create listener on port 80 in the ALB and redirect to 443
* Refactor security groups to reduced open ports
* Create variable to store the ARN of the secret with 1Password scimsession file
* Create variables to store ECS task memory and cpu
* Add default empty map as default of tags variable
* Remove provider
* Remove restrictions on Terraform version