### PR TITLE
Update Kubernetes deployment example

### DIFF
--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -16,7 +16,12 @@ spec:
         - name: op-scim-bridge
           image: 1password/scim:v2.3.1
           ports:
-            - containerPort: 3002
+            # HTTPS port (external TCP traffic should be forwarded to this port by default)
+            - name: https
+              containerPort: 8443
+            # HTTP port (forward unencrypted traffic to this port if not using Let's Encrypt)
+            - name: http
+              containerPort: 3002
           volumeMounts:
             - name: scimsession
               mountPath: "/secret"

--- a/kubernetes/op-scim-service.yaml
+++ b/kubernetes/op-scim-service.yaml
@@ -6,17 +6,18 @@ metadata:
     app: op-scim-bridge
 spec:
   type: LoadBalancer
-  # Traffic on :80 is needed for the status page and to perform the 
-  # LetsEncrypt certificate challenges after which all SCIM traffic
-  # will be served on :443.
   ports:
+  # Use this port in the standard configuration to terminate TLS at the SCIM
+  # bridge container using Let's Encrypt
   - protocol: TCP
     name: https
     port: 443
-    targetPort: 8443
-  - protocol: TCP
-    name: http
-    port: 80
-    targetPort: 8080
+    targetPort: https
+  # Use this port when terminating TLS in front of the SCIM bridge to listen
+  # for unencrypted traffic redirected from a reverse proxy or load balancer
+  #- protocol: TCP
+  #  name: http
+  #  port: 3002
+  #  targetPort: http
   selector:
     app: op-scim-bridge

--- a/kubernetes/redis-deployment.yaml
+++ b/kubernetes/redis-deployment.yaml
@@ -17,3 +17,4 @@ spec:
         image: redis:latest
         ports:
         - containerPort: 6379
+          name: redis

--- a/kubernetes/redis-service.yaml
+++ b/kubernetes/redis-service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
   - port: 6379
-    targetPort: 6379
+    targetPort: redis
   selector:
     app: op-scim-redis


### PR DESCRIPTION
This PR is to make several small changes to our generic Kubernetes deployment example:
- removes references to port `8080`, which is no longer necessary with our latest Let's Encrypt implementation
- adds names to the ports on the SCIM bridge and Redis containers and a description of their intended purpose
- references the above names for the `targetPort` in the respective Service specs (rather than explict port number)