### PR TITLE
Fix HTTP port when not using Let's Encrypt

### DIFF
--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -12,5 +12,5 @@ data:
   OP_DEBUG: "0"
   OP_PING_SERVER: "0"
   # (optional) uncomment this line to change the email that is used when Let's Encrypt issues your SCIM bridge a certificate
-  # default: "1pw@[OP_LETSENCRYPT_DOMAIN]" 
+  # default: "1pw@[OP_LETSENCRYPT_DOMAIN]"
   #OP_LETSENCRYPT_EMAIL: "1pw@example.com"

--- a/kubernetes/op-scim-service.yaml
+++ b/kubernetes/op-scim-service.yaml
@@ -17,7 +17,7 @@ spec:
     # for unencrypted traffic redirected from a reverse proxy or load balancer
     #- protocol: TCP
     #  name: http
-    #  port: 3002
+    #  port: 80
     #  targetPort: http
   selector:
     app: op-scim-bridge

--- a/kubernetes/op-scim-service.yaml
+++ b/kubernetes/op-scim-service.yaml
@@ -15,9 +15,9 @@ spec:
       targetPort: https
     # Use this port when terminating TLS in front of the SCIM bridge to listen
     # for unencrypted traffic redirected from a reverse proxy or load balancer
-    #- protocol: TCP
-    #  name: http
-    #  port: 80
-    #  targetPort: http
+    # - protocol: TCP
+    #   name: http
+    #   port: 80
+    #   targetPort: http
   selector:
     app: op-scim-bridge

--- a/kubernetes/op-scim-service.yaml
+++ b/kubernetes/op-scim-service.yaml
@@ -7,17 +7,17 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  # Use this port in the standard configuration to terminate TLS at the SCIM
-  # bridge container using Let's Encrypt
-  - protocol: TCP
-    name: https
-    port: 443
-    targetPort: https
-  # Use this port when terminating TLS in front of the SCIM bridge to listen
-  # for unencrypted traffic redirected from a reverse proxy or load balancer
-  #- protocol: TCP
-  #  name: http
-  #  port: 3002
-  #  targetPort: http
+    # Use this port in the standard configuration to terminate TLS at the SCIM
+    # bridge container using Let's Encrypt
+    - protocol: TCP
+      name: https
+      port: 443
+      targetPort: https
+    # Use this port when terminating TLS in front of the SCIM bridge to listen
+    # for unencrypted traffic redirected from a reverse proxy or load balancer
+    #- protocol: TCP
+    #  name: http
+    #  port: 3002
+    #  targetPort: http
   selector:
     app: op-scim-bridge

--- a/kubernetes/redis-deployment.yaml
+++ b/kubernetes/redis-deployment.yaml
@@ -13,8 +13,8 @@ spec:
         app: op-scim-redis
     spec:
       containers:
-      - name: op-scim-redis
-        image: redis:latest
-        ports:
-        - containerPort: 6379
-          name: redis
+        - name: op-scim-redis
+          image: redis:latest
+          ports:
+            - containerPort: 6379
+              name: redis

--- a/kubernetes/redis-service.yaml
+++ b/kubernetes/redis-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: op-scim-redis
 spec:
   ports:
-  - port: 6379
-    targetPort: redis
+    - port: 6379
+      targetPort: redis
   selector:
     app: op-scim-redis


### PR DESCRIPTION
### Overview

In this PR we update the HTTP port for the Load Balancer config. We don't need to change it to `3002` since we now use named ports. 

Note that there are some whitespace changes related to fixing the indentation and removing trailing whitespace in comments.

Resolves #177.

### To test

1. Set the the config value (in `kubernetes/op-scim-config.yaml`) `OP_LETSENCRYPT_DOMAIN` to `""` to disable Let's Encrypt
1. Uncomment the following lines in `kubernetes/op-scim-service.yaml`:
    ```
    #- protocol: TCP
    #  name: http
    #  port: 80
    #  targetPort: http
    ``` 
1. Connect `kubectl` to your favourite cluster
1. Apply this configuration to your cluster `kubectl apply -f .` or `kubectl apply -f ./kubernetes`
1. Navigate to the public IP address of the load balancer or configured domain
1. Ensure that you see the login page for the SCIM bridge, and _not_ the setup page 