### PR TITLE
Set resource requests and limits for application pods

### DIFF
--- a/kubernetes/op-redis-config.yaml
+++ b/kubernetes/op-redis-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: op-redis-configmap
+data:
+  # Set the arguments passed to Redis
+  # - maxmemory configures Redis to use a specified amount of memory for the data set
+  # - maxmemory-policy is the eviction policy used when the maximum memory is reached
+  REDIS_ARGS: "--maxmemory 256mb --maxmemory-policy volatile-lru"

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -26,6 +26,13 @@ spec:
             - name: scimsession
               mountPath: "/secret"
               readOnly: false
+          resources:
+            requests:
+              cpu: 125m
+              memory: 256M
+            limits:
+              cpu: 250m
+              memory: 512M
           envFrom:
             - configMapRef:
                 name: op-scim-configmap

--- a/kubernetes/redis-deployment.yaml
+++ b/kubernetes/redis-deployment.yaml
@@ -25,6 +25,6 @@ spec:
             limits:
               cpu: 250m
               memory: 512M
-          env:
-            - name: "REDIS_ARGS"
-              value: "--maxmemory 256mb --maxmemory-policy volatile-lru"
+          envFrom:
+            - configMapRef:
+                name: op-redis-configmap

--- a/kubernetes/redis-deployment.yaml
+++ b/kubernetes/redis-deployment.yaml
@@ -18,3 +18,10 @@ spec:
           ports:
             - containerPort: 6379
               name: redis
+          resources:
+            requests:
+              cpu: 125m
+              memory: 256M
+            limits:
+              cpu: 250m
+              memory: 512M

--- a/kubernetes/redis-deployment.yaml
+++ b/kubernetes/redis-deployment.yaml
@@ -25,3 +25,6 @@ spec:
             limits:
               cpu: 250m
               memory: 512M
+          env:
+            - name: "REDIS_ARGS"
+              value: "--maxmemory 256mb --maxmemory-policy volatile-lru"


### PR DESCRIPTION
In this PR we set resource requests and limits for the SCIM bridge and Redis application pods.

We also set a max memory limit for Redis before the Redis server will start evicting keys based on the selected policy.

I tested this by deploying it to a k8s cluster and inspecting the deployments.

Resolves #166.

cc @ag-adampike 