### PR TITLE
Set Docker resource requests and limits

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     image: redis:latest
     networks:
       - op-scim
+    env_file: redis.env
     restart: always
 
 networks:

--- a/docker/compose/redis.env
+++ b/docker/compose/redis.env
@@ -1,0 +1,4 @@
+# Set the arguments passed to Redis:
+# - maxmemory configures Redis to use a specified amount of memory for the data set
+# - maxmemory-policy is the eviction policy used when the maximum memory is reached
+REDIS_ARGS="--maxmemory 256mb --maxmemory-policy volatile-lru"

--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -28,6 +28,7 @@ services:
         condition: any
     networks:
       - op-scim
+    env_file: redis.env
 
 networks:
   op-scim:

--- a/docker/swarm/redis.env
+++ b/docker/swarm/redis.env
@@ -1,0 +1,4 @@
+# Set the arguments passed to Redis:
+# - maxmemory configures Redis to use a specified amount of memory for the data set
+# - maxmemory-policy is the eviction policy used when the maximum memory is reached
+REDIS_ARGS="--maxmemory 256mb --maxmemory-policy volatile-lru"


### PR DESCRIPTION
This PR updates the arguments passed to Redis to ensure that we have a max limit set for memory usage and select an eviction policy.

I followed the pattern used for the SCIM bridge application and introduced an environment variable file `redis.env` instead of directly injecting the values into the `YAML`.

Similar to #180 did for Kubernetes.

cc @ag-adampike. 🙏 