### PR TITLE
Update Kubernetes deployment example README

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -45,7 +45,7 @@ cd scim-examples/kubernetes/
 
 The following requires that you’ve completed the initial setup of Automated User Provisioning in your 1Password account. See [our support article](https://support.1password.com/scim/#step-1-prepare-your-1password-account) for more details.
 
-Once complete, create a Kubernetes Secret containing the contents of the `scimsession` file. Using `kubectl`, we can read the `scimsession` file and create the Kubernetes Secret in one command (use `--from-file=scimsession=[<path>/]<filename>` if your scimsession file was renamed and/or saved in another directory):
+Once complete, create a Kubernetes Secret containing the contents of the `scimsession` credentials file. Using `--from-file=[key=]source` when [creating the Kubernetes Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#create-a-secret), we can create the Kubernetes Secret named `scimsession`, specify the `scimsession` key, and set its value as the contents of the `scimsession` file in one command:
 
 ```bash
 kubectl create secret generic scimsession --from-file=scimsession=scimsession

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -45,10 +45,10 @@ cd scim-examples/kubernetes/
 
 The following requires that you’ve completed the initial setup of Automated User Provisioning in your 1Password account. See [our support article](https://support.1password.com/scim/#step-1-prepare-your-1password-account) for more details.
 
-Once complete, create a Kubernetes Secret containing the contents of the `scimsession` credentials file. Using `--from-file=[key=]source` when [creating the Kubernetes Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#create-a-secret), we can create the Kubernetes Secret named `scimsession`, specify the `scimsession` key, and set its value as the contents of the `scimsession` file in one command:
+Once complete, create a Kubernetes Secret containing the contents of the `scimsession` credentials file. Using `--from-file=[key=]source` when [creating the Kubernetes Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#create-a-secret), we can create the Kubernetes Secret named `scimsession`, specify the `scimsession` key, and set its value as the contents of the `scimsession` file in one command (replace `./scimsession` if the file is saved in another directory and/or with a different filename):
 
 ```bash
-kubectl create secret generic scimsession --from-file=scimsession=scimsession
+kubectl create secret generic scimsession --from-file=scimsession=./scimsession
 ```
 
 ## (Optional) Create the Google Workspace Kubernetes secrets

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -41,14 +41,14 @@ You can then browse to the Kubernetes directory:
 cd scim-examples/kubernetes/
 ```
 
-## Create the `scimsession` Kubernetes secret
+## Create the `scimsession` Kubernetes Secret
 
-The following requires that you’ve completed the initial setup of Provisioning in your 1Password Account. [See here](https://support.1password.com/scim/#step-1-prepare-your-1password-account) for more details.
+The following requires that you’ve completed the initial setup of Automated User Provisioning in your 1Password account. See [our support article](https://support.1password.com/scim/#step-1-prepare-your-1password-account) for more details.
 
-Once complete, you must create a Kubernetes secret containing the `scimsession` file. Using `kubectl`, we can read the `scimsession` file and create the Kubernetes secret in one command:
+Once complete, create a Kubernetes Secret containing the contents of the `scimsession` file. Using `kubectl`, we can read the `scimsession` file and create the Kubernetes Secret in one command (use `--from-file=scimsession=[<path>/]<filename>` if your scimsession file was renamed and/or saved in another directory):
 
 ```bash
-kubectl create secret generic scimsession --from-file=/path/to/scimsession
+kubectl create secret generic scimsession --from-file=scimsession=scimsession
 ```
 
 ## (Optional) Create the Google Workspace Kubernetes secrets


### PR DESCRIPTION
This PR is to fix an issue where renaming the scimsession file causes the bridge to start in setup mode.

The instructions are amended to explicitly set the `scimsession` key when creating the Secret so the bridge doesn't come up in setup mode if the scimsession file is renamed to something else.

To test, confirm that after renaming the scimsession file to something other than `scimsession`, the SCIM bridge deploys correctly and does not start in setup mode when using the `--from-file=scimsession=[<path>/]<filename>` flag with the new filename.