### PR TITLE
Kubernetes deployment example improvements

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -113,7 +113,7 @@ You can now continue with the administration guide to configure your Identity Pr
 
 ## Updating
 
-To update SCIM bridge, connect to your Kubernetes cluster and run the follwing command:
+To update SCIM bridge, connect to your Kubernetes cluster and run the following command:
 
 ```bash
 kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.4.1

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -116,7 +116,7 @@ You can now continue with the administration guide to configure your Identity Pr
 To update SCIM bridge, connect to your Kubernetes cluster and run the following command:
 
 ```bash
-kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.4.1
+kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.5.0
 ```
 
 This will upgrade your SCIM bridge to the latest version, which should take about 2-3 minutes for Kubernetes to process.

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: op-scim-configmap
 data:
   # Set this to the FQDN you've selected for your SCIM Bridge deployment
-  OP_LETSENCRYPT_DOMAIN: "scim.example.com"
+  OP_LETSENCRYPT_DOMAIN: ""
   # (advanced) only change the options below if you need to
   OP_REDIS_URL: "redis://op-scim-redis:6379"
   OP_SESSION: "/secret/scimsession"


### PR DESCRIPTION
This is a quick PR to rework our Kubernetes deployment example:

- Changes the order of the instructions slightly.
- Defaults to starting without Let's Encrypt by setting the `OP_LETSENCRYPT_DOMAIN` env var to `""`.
- Sets it using `kubectl` _after_ deploying SCIM bridge, allowing the DNS record to propagate before setting it up. Kubernetes does a rolling restart of the pod with the command, so no need for scaling or extra commands, and Let's Encrypt is presumably less likely to fail.
- Revamps the update instructions similarly and for similar reasons; also avoids overwriting config through a pull (note we will want to add this line to the list of items needing to be updated whenever we release a new version, wherever that is tracked).
- Minor clerical fixes throughout sections I was changing: dropping the definite article when referring to SCIM bridge, tweaks for concisencess, readability and clarity.

To test, deploy and test SCIM bridge on a Kubernetes cluster using the updated instructions. Change the image of SCIM bridge to a different version using the update command, and confirm the bridge redeploys using the new version.