### PR TITLE
Bump to v2.6.0

### DIFF
--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "op_scim_bridge",
-    "image": "1password/scim:v2.5.1",
+    "image": "1password/scim:v2.6.0",
     "cpu": 128,
     "memory": 512,
     "essential": true,

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   scim:
-    image: 1password/scim:v2.5.1
+    image: 1password/scim:v2.6.0
     ports:
       - "3002:3002"
       - "80:8080"

--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   scim:
-    image: 1password/scim:v2.5.1
+    image: 1password/scim:v2.6.0
     deploy:
       replicas: 1
       restart_policy:

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -116,7 +116,7 @@ You can now continue with the administration guide to configure your Identity Pr
 To update SCIM bridge, connect to your Kubernetes cluster and run the following command:
 
 ```bash
-kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.5.1
+kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.6.0
 ```
 
 This will upgrade your SCIM bridge to the latest version, which should take about 2-3 minutes for Kubernetes to process.

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: op-scim-bridge
-          image: 1password/scim:v2.5.1
+          image: 1password/scim:v2.6.0
           ports:
             # HTTPS port (external TCP traffic should be forwarded to this port by default)
             - name: https


### PR DESCRIPTION
Bumps the image tag to v2.6.0.

See this link for changelog: https://app-updates.agilebits.com/product_history/SCIM