### PR TITLE
Introduce Google Workspace configuration for AWS Terraform deployment example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ terraform.tfstate.backup
 terraform.tfvars
 .terraform*
 *.plan
+workspace-*.json

--- a/aws-ecsfargate-terraform/README.md
+++ b/aws-ecsfargate-terraform/README.md
@@ -27,6 +27,34 @@ Copy `terraform.tfvars.template` to `terraform.tfvars`:
 cp terraform.tfvars.template terraform.tfvars
 ```
 
+<details>
+  <summary>Optional: For customers using Google Workspace</summary>
+
+### Copy Google Worskpace credentials
+
+Copy the `workspace-settings.json` template file to this Terraform code directory:
+
+```bash
+cp ../beta/workspace-settings.json ./workspace-settings.json
+```
+Edit this file and add the respective values for each variable (see our [Google Workspace documentation](https://support.1password.com/scim-google-workspace/)).
+
+Copy your `workspace-credentials.json` file to this Terraform code directory:
+
+```bash
+cp <path>/workspace-credentials.json ./workspace-credentials.json
+```
+
+### Enable Google Workspace configuration
+
+Uncommment this line in `terraform.tfvars`:
+
+```terraform
+using_google_workspace = true
+```
+
+</details>
+
 ### Copy `scimsession` file
 
 Copy the `scimsession` file in the Terraform code directory:

--- a/aws-ecsfargate-terraform/README.md
+++ b/aws-ecsfargate-terraform/README.md
@@ -81,65 +81,70 @@ Set the `aws_region` variable in `terraform.tfvars` to the AWS region you're dep
 
 This example uses AWS Certificate Manager to manage the required TLS certificate. Save the full domain name you want to use as `domain_name` in `terraform.tfvars`:
 
-```
+```terraform
 domain_name = "<scim.example.com>"
 ```
 
-### (Optional) Use an existing ACM wildcard certificate
+<details>
+  <summary>Optional: Configure additional features</summary>
+
+
+### Use an existing ACM wildcard certificate
 
 If you would like to use an existing wildcard certificate in AWS Certificate Manager (`*.example.com`), uncommment this line in `terraform.tfvars`:
 
-```
+```terraform
 wildcard_cert = true
 ```
 
-### (Optional) External DNS 
+### External DNS 
 
-This deployment example uses Route 53 to create the required DNS record. If you are using another DNS provider, uncommment this line in `terraform.tfvars`:
+This deployment example uses Route 53 to create the required DNS record by default. If you are using another DNS provider, uncommment this line in `terraform.tfvars`:
 
-```
+```terraform
 using_route53 = false
 ```
 
 Create a CNAME record pointing to the `loadbalancer-dns-name` output printed out from `terraform apply`.
 
-### (Optional) Use an existing VPC
+### Use an existing VPC
 
 This deployment example uses the default VPC for your AWS region. If you would like to specify another VPC to use instead, set the value in the `vpc_name` in `terraform.tfvars`:
 
-```
+```terraform
 vpc_name           = "<name_of_VPC>"
 ```
 
-### (Optional) Specify a name prefix
+### Specify a name prefix
 
 If you would like to specify a common prefix for naming all supported AWS resources created by Terraform, set the value in the `name_prefix` variable in `terraform.tfvars`:
 
-```
+```terraform
 name_prefix        = "<prefix>"
-
 ```
 
-### (Optional) Set a log retention period
+### Set a log retention period
 
 Thw deployment example retains logs indifnietely by default. If you would like to set a differnet retention period, specify a number of days in the `log_retention_days` variable in `terraform.tfvars`:
 
-```
+```terraform
 log_retention_days = <number_of_days>
 
 ```
 
-### (Optional) Apply additional tags
+### Apply additional tags
 
-If you would apply additional tags to all supported AWS resources created by Terraform, add some to the `tags` variable in `terraform.tfvars`:
+To apply additional tags to all supported AWS resources created by Terraform, add keys and values to the `tags` variable in `terraform.tfvars`:
 
-```
+```terraform
 tags = {
   <key1> = "<some_value>"
   <key2> = "<some_value>"
   …
 }
 ```
+
+</details>
 
 ## Deploy
 

--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -18,7 +18,7 @@ locals {
   domain      = join(".", slice(split(".", var.domain_name), 1, length(split(".", var.domain_name))))
   tags = merge(var.tags, {
     application = "1Password SCIM Bridge",
-    version     = trimprefix(jsondecode(file("task-definitions/scim.json"))[0].image, "1password/scim:v")
+    version     = trimprefix(jsondecode(file("${path.module}/task-definitions/scim.json"))[0].image, "1password/scim:v")
   })
 
   # Define base configuration from ./task-definitions/scim.json
@@ -115,7 +115,7 @@ resource "aws_secretsmanager_secret" "scimsession" {
 
 resource "aws_secretsmanager_secret_version" "scimsession" {
   secret_id     = aws_secretsmanager_secret.scimsession.id
-  secret_string = base64encode(file("${path.module}/scimsession"))
+  secret_string = filebase64("${path.module}/scimsession")
 }
 
 resource "aws_cloudwatch_log_group" "op_scim_bridge" {
@@ -172,7 +172,7 @@ resource "aws_ecs_service" "op_scim_bridge" {
 
   load_balancer {
     target_group_arn = aws_lb_target_group.op_scim_bridge.arn
-    container_name   = jsondecode(file("task-definitions/scim.json"))[0].name
+    container_name   = jsondecode(file("${path.module}/task-definitions/scim.json"))[0].name
     container_port   = 3002
   }
 

--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -20,6 +20,41 @@ locals {
     application = "1Password SCIM Bridge",
     version     = trimprefix(jsondecode(file("task-definitions/scim.json"))[0].image, "1password/scim:v")
   })
+
+  # Define base configuration from ./task-definitions/scim.json
+  base_container_definitions_json = templatefile(
+    "${path.module}/task-definitions/scim.json",
+    {
+      secret_arn     = aws_secretsmanager_secret.scimsession.arn,
+      aws_logs_group = aws_cloudwatch_log_group.op_scim_bridge.name,
+      region         = var.aws_region,
+    }
+  )
+
+  # Split base config array into discrete container definitions
+  base_scim_bridge_container_definition = jsondecode(local.base_container_definitions_json)[0]
+  base_redis_container_definition       = jsondecode(local.base_container_definitions_json)[1]
+
+  # Conditionally merge Google Workspace config
+  scim_bridge_container_definition = !var.using_google_workspace ? local.base_scim_bridge_container_definition : merge(
+    local.base_scim_bridge_container_definition,
+    {
+      #Add Google Workspace secrets to current list
+      secrets = concat(
+        local.base_scim_bridge_container_definition.secrets,
+        module.google_workspace[0].secrets,
+      )
+    }
+  )
+
+  # Create local variable for merging in config to Redis container
+  redis_container_definition = local.base_redis_container_definition
+
+  # Combine discrete container definitions into list
+  container_definitions = [
+    local.scim_bridge_container_definition,
+    local.redis_container_definition,
+  ]
 }
 
 data "aws_vpc" "this" {
@@ -97,12 +132,9 @@ resource "aws_ecs_cluster" "op_scim_bridge" {
 }
 
 resource "aws_ecs_task_definition" "op_scim_bridge" {
-  family = var.name_prefix == "" ? "op_scim_bridge" : format("%s_%s", local.name_prefix, "scim_bridge")
-  container_definitions = templatefile("task-definitions/scim.json",
-    { secret_arn     = aws_secretsmanager_secret.scimsession.arn,
-      aws_logs_group = aws_cloudwatch_log_group.op_scim_bridge.name,
-      region         = var.aws_region
-  })
+  family                = var.name_prefix == "" ? "op_scim_bridge" : format("%s_%s", local.name_prefix, "scim_bridge")
+  container_definitions = jsonencode(local.container_definitions)
+
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   memory                   = 1024
@@ -295,6 +327,17 @@ resource "aws_route53_record" "op_scim_bridge" {
     zone_id                = aws_alb.op_scim_bridge.zone_id
     evaluate_target_health = true
   }
+}
+
+module "google_workspace" {
+  count = var.using_google_workspace ? 1 : 0
+
+  source = "../beta/aws-terraform-gw"
+
+  name_prefix = local.name_prefix
+  tags        = local.tags
+  iam_role    = aws_iam_role.op_scim_bridge
+  enabled     = var.using_google_workspace
 }
 
 moved {

--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -14,7 +14,8 @@
     "portMappings": [
       {
         "containerPort": 3002,
-        "hostPort": 3002
+        "hostPort": 3002,
+        "protocol": "tcp"
       }
     ],
     "environment": [
@@ -40,7 +41,9 @@
         "awslogs-region": "${region}",
         "awslogs-stream-prefix": "ecs-scim"
       }
-    }
+    },
+    "mountPoints" : [],
+    "volumesFrom" : []
   },
   {
     "name": "redis",
@@ -60,7 +63,8 @@
     "portMappings": [
       {
         "containerPort": 6379,
-        "hostPort": 6379
+        "hostPort": 6379,
+        "protocol": "tcp"
       }
     ],
     "environment": [
@@ -68,6 +72,8 @@
         "name": "REDIS_ARGS",
         "value": "--maxmemory 256mb --maxmemory-policy volatile-lru"
       }
-    ]
+    ],
+    "mountPoints" : [],
+    "volumesFrom" : []
   }
 ]

--- a/aws-ecsfargate-terraform/terraform.tfvars.template
+++ b/aws-ecsfargate-terraform/terraform.tfvars.template
@@ -1,14 +1,14 @@
 # Required: Set a domain name for your SCIM bridge
-domain_name   = "scim.example.com"
+domain_name = "scim.example.com"
 
 # Optional: Specify a different region
-aws_region    = "us-east-1"
+aws_region = "us-east-1"
 
 # Optional: Specify an existing VPC to use, add a common name prefix to all resources, specify the CloudWatch Logs retention period, and add tags for all supported resources.
 vpc_name           = ""
 name_prefix        = ""
 log_retention_days = 0
-tags               = {
+tags = {
   #key = "value"
 }
 

--- a/aws-ecsfargate-terraform/terraform.tfvars.template
+++ b/aws-ecsfargate-terraform/terraform.tfvars.template
@@ -17,3 +17,6 @@ tags               = {
 
 # Uncomment the below line if you are *not* using Route 53
 #using_route53 = false
+
+# Uncomment the below line to enable Google Workspace configuraton for 1Password SCIM bridge
+#using_google_workspace = true

--- a/aws-ecsfargate-terraform/variables.tf
+++ b/aws-ecsfargate-terraform/variables.tf
@@ -37,5 +37,11 @@ variable "using_route53" {
 
 variable "log_retention_days" {
   type        = number
-  description = "Specifies the number of days to retain log events in CloudWatch. Set to the default of 0, the log is retained indefinitely."
+}
+
+# (For customers using Google Workspace participants)
+variable "using_google_workspace" {
+  type        = bool
+  default     = false
+  description = "Set to true to add Google Workspace configuration to 1Password SCIM bridge"
 }

--- a/aws-ecsfargate-terraform/variables.tf
+++ b/aws-ecsfargate-terraform/variables.tf
@@ -37,6 +37,7 @@ variable "using_route53" {
 
 variable "log_retention_days" {
   type        = number
+  description = "Specifies the number of days to retain log events in CloudWatch. The log is retained indefinitely whne set to 0."
 }
 
 # (For customers using Google Workspace participants)

--- a/beta/aws-terraform-gw/README.md
+++ b/beta/aws-terraform-gw/README.md
@@ -1,0 +1,6 @@
+# 1Password SCIM bridge Google Workspace module
+
+This is an initial beta release of a Terraform module to manage the configuration required to support automated provisioning with Google Workspace. This module:
+- Creates AWS secrets to store the Google Workspace config
+- Creates an IAM policy to read the secrets and attaches it to the role passed into the module
+- Outputs a list of `secrets` objects to append to the SCIM bridge container definition

--- a/beta/aws-terraform-gw/main.tf
+++ b/beta/aws-terraform-gw/main.tf
@@ -1,0 +1,56 @@
+locals {
+  # Define secret reference list
+  secrets = [
+    {
+      name      = "OP_WORKSPACE_CREDENTIALS"
+      valueFrom = aws_secretsmanager_secret.workspace_credentials.arn
+    },
+    {
+      name      = "OP_WORKSPACE_SETTINGS",
+      valueFrom = aws_secretsmanager_secret.workspace_settings.arn,
+    },
+  ]
+}
+
+# Construct an IAM policy document
+data "aws_iam_policy_document" "this" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      aws_secretsmanager_secret.workspace_settings.arn,
+      aws_secretsmanager_secret.workspace_credentials.arn,
+    ]
+  }
+}
+
+# Create a policy from the document and attach it to the IAM role
+resource "aws_iam_role_policy" "this" {
+  name_prefix = var.name_prefix
+  policy      = data.aws_iam_policy_document.this.json
+  role        = var.iam_role.name
+}
+
+resource "aws_secretsmanager_secret" "workspace_settings" {
+  name_prefix = var.name_prefix
+
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "workspace_settings" {
+  secret_id     = aws_secretsmanager_secret.workspace_settings.id
+  secret_string = var.enabled ? filebase64("${path.root}/workspace-settings.json") : null
+}
+
+resource "aws_secretsmanager_secret" "workspace_credentials" {
+  name_prefix = var.name_prefix
+
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "workspace_credentials" {
+  secret_id     = aws_secretsmanager_secret.workspace_credentials.id
+  secret_string = var.enabled ? filebase64("${path.root}/workspace-credentials.json") : null
+}

--- a/beta/aws-terraform-gw/outputs.tf
+++ b/beta/aws-terraform-gw/outputs.tf
@@ -1,0 +1,4 @@
+output "secrets" {
+  description = "Google Workspace secret references to append to container definition environment."
+  value       = local.secrets
+}

--- a/beta/aws-terraform-gw/variables.tf
+++ b/beta/aws-terraform-gw/variables.tf
@@ -1,0 +1,21 @@
+variable "name_prefix" {
+  type        = string
+  description = "A common prefix to apply to the names of all AWS resources."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A set of tags to apply to all respective AWS resources."
+}
+
+variable "iam_role" {
+  type = object({
+    name = string
+  })
+  description = "The IAM role to which the policy to read the Google Workspace credentials should be attached."
+}
+
+variable "enabled" {
+  type        = bool
+  description = "Whether or not the module is enabled."
+}

--- a/beta/workspace-settings.json
+++ b/beta/workspace-settings.json
@@ -1,5 +1,4 @@
 {
     "actor":"admin.email.goes.here@example.com",
-    "domain":"example.1password.com",
     "bridgeAddress":"https://bridge.example.com"
 }


### PR DESCRIPTION
This PR introduces a Google Workspace module for the AWS deployment example to conditionally:

- create AWS secrets for the Workspace configuration files
- create a role policy to access the above secrets and attach it to the IAM role for the ECS task
- merge the secret references into the task definition to enable the container environment to consume the secret values

Other changes:

- `workspace-*.json` added to `.gitignore` to avoid commiting secrets to repos
- white space formatting for readability and clarity
- updates to the readme for readability and clarity
- added some default null values to the task definition file for a cleaner `terraform apply` between runs
- a few updated function calls to simplifiy and encode some file paths 

To test:

- [x] 1. Deploy 1Password SCIM bridge on AWS using the current example cloned from `master`
- [x] 2. Switch to this branch.
- [x] 3. Run `terraform apply` in the current configuration. Confirm no breaking changes and accept the plan.
- [x] 4. Copy the necessary config files to the Terraform directory and uncomment the `using_google_workspace = true` in `terraform.tfvars` as instructed in the amended README.
- [x] 5. Run `terraform apply` in the update configuration. Confirm the creation of the additonal resources and merged configuration as noted above and accept the changes.
- [x] 6. Confirm additional resources and configuration in AWS console:
  - [x] i. AWS secrets for each respective workspace config file that `base64` decode to the original value .
  - [x] ii. Additional environment variables that reference the resepective AWS secret ARNs.
- [x] 7. Confirm connection to Google Workspace.

Resolves #200.

cc @black-bryan @scottisloud