### PR TITLE
Remove unused field in workspace settings example

### DIFF
--- a/beta/workspace-settings.json
+++ b/beta/workspace-settings.json
@@ -1,5 +1,4 @@
 {
-    "actor":"admin.email.goes.here@example.com",
-    "domain":"example.1password.com",
-    "bridgeAddress":"https://bridge.example.com"
+	"actor": "admin.email.goes.here@example.com",
+	"bridgeAddress": "https://bridge.example.com"
 }


### PR DESCRIPTION
We recently removed the need for consuming the customer's `domain` as part of the workspace configuration set up. This is a bit of cleanup from that work, removing it from an example.