### PR TITLE
Add note about increasing bridge and redis deployments, add commands

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -208,7 +208,7 @@ This proposal is 4x the CPU and 2x the memory of the default values. These value
 
 Configuring these values can be done with Kubernetes commands. You can get the names of the deployments with `kubectl get deployments`.
 
-```
+```bash
 # scale down deployment
 kubectl scale --replicas=0 deployment/op-scim-bridge
 


### PR DESCRIPTION
This work stems mainly from https://gitlab.1password.io/dev/b5/op/-/issues/3008.

Speaking with customers, our current documentation is not clear that we are recommending resources be upgraded for both the SCIM bridge _and_ Redis deployments, so we clarify that here.

Also, adding k8s commands directly in the `README.md` can reduce customer service inquires, and adding them explicitly can further clarify that both deployments need upgrading.

The actual values proposed are not changed, but I removed the parenthetical values because they only add confusion.