### PR TITLE
Bump to v2.7.4, introduce manual TLS certificate functionality

### DIFF
--- a/PREPARATION.md
+++ b/PREPARATION.md
@@ -20,9 +20,11 @@ For general deployment, the SCIM bridge requires three things to function correc
 
 You will need to be able to create a DNS record with the SCIM bridge domain name decided. However, you'll need to have the IP address of the host, which necessitates deploying the SCIM bridge first, unless you have a static IP already assigned. Follow the steps in each respective deployment guide on when to finish setting up your DNS record.
 
-### SSL Certificates
+### TLS Certificates
 
-SSL certificates are handled through the [https://letsencrypt.org/](LetsEncrypt) service which automatically generates and renews an SSL certificate based on the domain name you've decided on. On your firewall, you should ensure that the service can access Port 80 and Port 443, as Port 80 is required for the LetsEncrypt service to complete its domain challenge and issue your SCIM bridge an SSL certificate. Note that a TLS connection is mandatory for connecting to the 1Password service.
+Identity Providers typically require a TLS certificate when communicating to the SCIM bridge under most circumstances.
+
+By default, TLS certificates are handled through a complimentary [Let's Encrypt](https://letsencrypt.org/) service integration, which automatically generates and renews an TLS certificate based on the domain name you've decided on. On your firewall, you should ensure that the service can access port `443`, as port `443` is required for the Let's Encrypt service to complete its domain challenge and issue your SCIM bridge a TLS certificate. 
 
 ## Clone this repository
 

--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "op_scim_bridge",
-    "image": "1password/scim:v2.7.3",
+    "image": "1password/scim:v2.7.4",
     "cpu": 128,
     "memory": 512,
     "essential": true,
@@ -24,7 +24,7 @@
         "value": "redis://localhost:6379"
       },
       {
-        "name": "OP_LETSENCRYPT_DOMAIN",
+        "name": "OP_TLS_DOMAIN",
         "value": ""
       }
     ],

--- a/beta/do-app-platform-op-cli/op-scim-bridge.yaml
+++ b/beta/do-app-platform-op-cli/op-scim-bridge.yaml
@@ -32,7 +32,7 @@ services:
     registry: 1password
     registry_type: DOCKER_HUB
     repository: scim
-    tag: v2.7.3
+    tag: v2.7.4
   instance_count: 1
   instance_size_slug: basic-xxs
   name: op-scim-bridge

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,9 +36,9 @@ The script will do the following:
 
 1. Prompt you if you are using Google Workspace as your Identity Provider and for configuration files locations to add them as a Docker Secrets within your Swarm cluster.
 2. Prompt if you are deploying using Docker Swarm or Docker Compose.
-3. Prompt you for your SCIM bridge domain name which will configure LetsEncrypt to automatically issue a certificate for your Bridge. This is the domain you selected in [PREPARATION.md](/PREPARATION.md).
+3. Prompt you for your SCIM bridge domain name which will configure Let's Encrypt to automatically issue a certificate for your Bridge. This is the domain you selected in [PREPARATION.md](/PREPARATION.md).
 4. Prompt you for your `scimsession` file location to add your `scimsession` file as a Docker Secret within your Swarm cluster.
-5. Deploy a container using `1password/scim`, and a `redis` container. The `redis` container is necessary to store LetsEncrypt certificates, as well as act as a cache for Identity Provider data.
+5. Deploy a container using `1password/scim`, and a `redis` container. The `redis` container is necessary to store Let's Encrypt certificates, as well as act as a cache for Identity Provider data.
 
 The logs from the SCIM bridge and Redis containers will be streamed to your machine. If everything seems to have deployed successfully, press Ctrl+C to exit, and the containers will remain running on the remote machine.
 
@@ -83,7 +83,7 @@ To use Docker Swarm to deploy, you’ll want to have run `docker swarm init` or 
 
 Unlike Docker Compose, you won’t need to set the `OP_SESSION` variable in `scim.env`, as we’ll be using Docker Secrets to store the `scimsession` file.
 
-You’ll still need to set the environment variable `OP_LETSENCRYPT_DOMAIN` within `scim.env` to the URL you selected during [PREPARATION.md](/PREPARATION.md). Open that in your preferred text editor and change `OP_LETSENCRYPT_DOMAIN` to that domain name.
+You’ll still need to set the environment variable `OP_TLS_DOMAIN` within `scim.env` to the URL you selected during [PREPARATION.md](/PREPARATION.md). Open that in your preferred text editor and change `OP_TLS_DOMAIN` to that domain name.
 
 ### Information for Google Workspace as your Identity Provider (IdP)
 If you’re using Google Workspace as your identity provider for provisioning, you will need to set up some additional secrets to use this functionality as detailed below. Refer to our complete Google Workspace provisioning documentation for more complete information, https://support.1password.com/scim-google-workspace. 
@@ -133,9 +133,9 @@ SESSION=$(cat /path/to/scimsession | base64 | tr -d "\n")
 sed -i '' -e "s/OP_SESSION=$/OP_SESSION=$SESSION/" ./scim.env
 ```
 
-You’ll also need to set the environment variable `OP_LETSENCRYPT_DOMAIN` within `scim.env` to the URL you selected during [PREPARATION.md](/PREPARATION.md). Open that in your preferred text editor and change `OP_LETSENCRYPT_DOMAIN` to that domain name.
+You’ll also need to set the environment variable `OP_TLS_DOMAIN` within `scim.env` to the URL you selected during [PREPARATION.md](/PREPARATION.md). Open that in your preferred text editor and change `OP_TLS_DOMAIN` to that domain name.
 
-Ensure that `OP_LETSENCRYPT_DOMAIN` is set to the domain name you’ve set up before continuing.
+Ensure that `OP_TLS_DOMAIN` is set to the domain name you’ve set up before continuing.
 
 ### Information for Google Workspace as your Identity Provider (IdP)
 If you’re using Google Workspace as your identity provider for provisioning, you will need to set up some additional secrets to use this functionality as detailed below. Refer to our complete Google Workspace provisioning documentation for more complete information, https://support.1password.com/scim-google-workspace. 
@@ -221,12 +221,13 @@ Unless you have customized your Redis deployment, there shouldn’t be any actio
 
 The following options are available for advanced or custom deployments. Unless you have a specific need, these options do not need to be modified.
 
-* `OP_PORT` - when `OP_LETSENCRYPT_DOMAIN` is set to blank, you can use `OP_PORT` to change the default port from 3002 to one of your choosing.
+* `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` - these two variables can be set to the paths of a key file and certificate file, which then disables Let's Encrypt functionality, causing the SCIM bridge to utilize your own manually-defined certificate when `OP_TLS_DOMAIN` is also defined. Note that this is only supported under Docker Swarm, not under Docker Compose.
+* `OP_PORT` - when `OP_TLS_DOMAIN` is set to blank, you can use `OP_PORT` to change the default port from 3002 to one of your choosing.
 * `OP_REDIS_URL` - you can specify `redis://` or `rediss://` (for TLS) URL here to point towards an alternative Redis host. You can then strip out the sections in `docker-compose.yml` that refer to Redis to not deploy that container. Note that Redis is still required for the SCIM bridge to function.
 * `OP_PRETTY_LOGS` - can be set to `1` if you would like the SCIM bridge to output logs in a human-readable format. This can be helpful if you aren’t planning on doing custom log ingestion in your environment.
 * `OP_DEBUG` - can be set to `1` to enable debug output in the logs. Useful for troubleshooting or when contacting 1Password Support.
 * `OP_TRACE` - can be set to `1` to enable Trace-level log output. Useful for debugging Let’s Encrypt integration errors.
-* `OP_PING_SERVER` - can be set to `1` to enable an optional `/ping` endpoint on port `80`. Useful for health checks. Disabled if `OP_LETSENCRYPT_DOMAIN` is unset and TLS is not utilized.
+* `OP_PING_SERVER` - can be set to `1` to enable an optional `/ping` endpoint on port `80`. Useful for health checks. Disabled if `OP_TLS_DOMAIN` is unset and TLS is not utilized.
 
 ## Generating `scim.env` file on Windows
 

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   scim:
-    image: 1password/scim:v2.7.3
+    image: 1password/scim:v2.7.4
     ports:
       - "3002:3002"
       - "80:8080"

--- a/docker/compose/scim.env
+++ b/docker/compose/scim.env
@@ -6,14 +6,14 @@
 # for Docker Compose, you will need to set this
 OP_SESSION=
 
-# OP_LETSENCRYPT_DOMAIN should be set to the domain you want to use for your SCIM Bridge
-# this will enable the complimentary LetsEncrypt challenge server
-OP_LETSENCRYPT_DOMAIN=op-scim.example.com
+# OP_TLS_DOMAIN should be set to the domain you want to use for your SCIM Bridge
+# this will enable the complimentary LetsEncrypt challenge server if OP_TLS_CERT_FILE and OP_TLS_KEY_FILE are not set (or valid)
+OP_TLS_DOMAIN=op-scim.example.com
 # alternatively, you can set the variable to blank, which will cause the SCIM Bridge to serve on port 3002
-#OP_LETSENCRYPT_DOMAIN=
+#OP_TLS_DOMAIN=
 
 # (ADVANCED) the options below aren't usually necessary during routine deployments, but can be used if you have a specific need
-# OP_PORT can be used to override the port number when the SCIM Bridge is running on port 3002 (when OP_LETSENCRYPT_DOMAIN is blank)
+# OP_PORT can be used to override the port number when the SCIM Bridge is running on port 3002 (when OP_TLS_DOMAIN is blank)
 #OP_PORT=3002
 
 # OP_REDIS_URL can be set if you are hosting your redis server at a different location
@@ -29,11 +29,11 @@ OP_REDIS_URL=redis://redis:6379
 # OP_TRACE enables Trace-level debugging, primarily used to debug Let's Encrypt integration errors
 #OP_TRACE=1
 
-# OP_LETSENCRYPT_EMAIL changes the email address provided to Let's Encrypt when a certificate is issued for your SCIM bridge, default: "1pw@[OP_LETSENCRYPT_DOMAIN]"
+# OP_LETSENCRYPT_EMAIL changes the email address provided to Let's Encrypt when a certificate is issued for your SCIM bridge, default: "1pw@[OP_TLS_DOMAIN]"
 #OP_LETSENCRYPT_EMAIL=scim@example.com
 
 # OP_PING_SERVER brings up a `/ping` endpoint which can be useful for health checks
-# It is disabled if OP_LETSENCRYPT_DOMAIN is unset
+# It is disabled if OP_TLS_DOMAIN is unset
 #OP_PING_SERVER=1
 
 # (GOOGLE WORKSPACE) the options below are intended for users of our Google Workspace integration

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -207,7 +207,7 @@ gw_docker_file=$docker_file_path/gw-docker-compose.yml
 docker_backup_file=$docker_file_path/docker-compose.yml.bak
 gw_docker_backup_file=$docker_file_path/gw_docker-compose.yml.bak
 cp $docker_file $docker_backup_file
-sed -i  -e "s/^OP_LETSENCRYPT_DOMAIN=.*$/OP_LETSENCRYPT_DOMAIN=$domain_name/" $docker_file_path/scim.env
+sed -i  -e "s/^OP_TLS_DOMAIN=.*$/OP_TLS_DOMAIN=$domain_name/" $docker_file_path/scim.env
 
 # run the function associated with the Docker type selected
 if [[ "$docker_type" == "compose" ]]

--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   scim:
-    image: 1password/scim:v2.7.3
+    image: 1password/scim:v2.7.4
     deploy:
       replicas: 1
       restart_policy:

--- a/docker/swarm/scim.env
+++ b/docker/swarm/scim.env
@@ -1,14 +1,22 @@
 # the following variables are options you can set for your SCIM Bridge
 # uncomment the lines you need
 
-# OP_LETSENCRYPT_DOMAIN should be set to the domain you want to use for your SCIM Bridge
-# this will enable the complimentary LetsEncrypt challenge server
-OP_LETSENCRYPT_DOMAIN=op-scim.example.com
+# OP_TLS_DOMAIN should be set to the domain you want to use for your SCIM Bridge
+# this will enable the complimentary Let's Encrypt challenge server if OP_TLS_CERT_FILE and OP_TLS_KEY_FILE are not set (or valid)
+OP_TLS_DOMAIN=op-scim.example.com
 # alternatively, you can set the variable to blank, which will cause the SCIM Bridge to serve on port 3002
-#OP_LETSENCRYPT_DOMAIN=
+#OP_TLS_DOMAIN=
 
 # (ADVANCED) the options below aren't usually necessary during routine deployments, but can be used if you have a specific need
-# OP_PORT can be used to override the port number when the SCIM Bridge is running on port 3002 (when OP_LETSENCRYPT_DOMAIN is blank)
+# OP_TLS_KEY_FILE defines the path of a valid SSL key file
+# NOTE: this must be combined with OP_TLS_CERT_FILE and be valid to work as expected
+#OP_TLS_KEY_FILE=/path/to/key.pem
+
+# OP_TLS_CERT_FILE defines the path of a valid SSL certificate file
+# NOTE: this must be combined with OP_TLS_KEY_FILE and be valid to work as expected
+#OP_TLS_CERT_FILE=/path/to/cert.pem
+
+# OP_PORT can be used to override the port number when the SCIM Bridge is running on port 3002 (when OP_TLS_DOMAIN is blank)
 #OP_PORT=3002
 
 # OP_REDIS_URL can be set if you are hosting your redis server at a different location
@@ -25,7 +33,7 @@ OP_REDIS_URL=redis://redis:6379
 #OP_TRACE=1
 
 # OP_PING_SERVER brings up a `/ping` endpoint which can be useful for health checks
-# It is disabled if OP_LETSENCRYPT_DOMAIN is unset
+# It is disabled if OP_TLS_DOMAIN is unset
 #OP_PING_SERVER=1
 
 # OP_SESSION can be either the base64-encoded string of a `scimsession` file, or it can be the path to a `scimsession` file (as in a Docker Swarm Secret)

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -114,10 +114,10 @@ Create a public DNS record pointing to this address as outlined in [the preparat
 
 ## Configure Let's Encrypt
 
-After the DNS record above has propagated, run the following command to set the `OP_LETSENCRYPT_DOMAIN` environment variable to the fully-qualified domain name (FQDN) for SCIM bridge based on this record (replace `scim.example.com` with the FQDN):
+After the DNS record above has propagated, run the following command to set the `OP_TLS_DOMAIN` environment variable to the fully-qualified domain name (FQDN) for SCIM bridge based on this record (replace `scim.example.com` with the FQDN):
 
 ```bash
-kubectl set env deploy/op-scim-bridge OP_LETSENCRYPT_DOMAIN=scim.example.com
+kubectl set env deploy/op-scim-bridge OP_TLS_DOMAIN=scim.example.com
 ```
 
 SCIM bridge will restart and acquire a TLS certificate using Let's Encrypt.
@@ -139,7 +139,7 @@ You can now continue with the administration guide to configure your Identity Pr
 To update SCIM bridge, connect to your Kubernetes cluster and run the following command:
 
 ```bash
-kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.7.3
+kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.7.4
 ```
 
 This will upgrade your SCIM bridge to the latest version, which should take about 2-3 minutes for Kubernetes to process.
@@ -148,7 +148,7 @@ This will upgrade your SCIM bridge to the latest version, which should take abou
 
 As of October 2020, the `scim-examples` Kubernetes deployment now uses `op-scim-config.yaml` to set the configuration needed for your SCIM bridge, and has changed the deployment names from `op-scim` to `op-scim-bridge`, and `redis` to `op-scim-redis` for clarity and consistency.
 
-You’ll need to re-configure your options in `op-scim-config.yaml`, particularly `OP_LETSENCRYPT_DOMAIN`. You may also want to delete your previous `op-scim` and `redis` deployments to prevent conflict between the two versions.
+You’ll need to re-configure your options in `op-scim-config.yaml`, particularly `OP_TLS_DOMAIN`. You may also want to delete your previous `op-scim` and `redis` deployments to prevent conflict between the two versions.
 
 ```bash
 kubectl delete deployment/op-scim deployment/redis
@@ -234,12 +234,16 @@ Please reach out to our [support team](https://support.1password.com/contact/) i
 
 Here are some helpful tips for customizing your 1Password SCIM bridge deployment:
 
-### External load balancer
+### Self-Managed TLS
 
-To use your own TLS certificate, terminate TLS traffic on a public-facing load balancer or reverse proxy and redirect HTTP traffic to SCIM bridge within your private network. Skip the step to [configure Let's Encrypt](#configure-lets-encrypt), or revert to the default state by setting `OP_LETSENCRYPT_DOMAIN` to `""`:
+There are two ways to use a self-managed TLS certificate, which disables Let's Encrypt functionality.
+
+#### Load Balancer
+
+The first is to terminate TLS traffic on a public-facing load balancer or reverse proxy and redirect HTTP traffic to SCIM bridge within your private network. Skip the step to [configure Let's Encrypt](#configure-lets-encrypt), or revert to the default state by setting `OP_TLS_DOMAIN` to `""`:
 
 ```bash
-kubectl set env deploy/op-scim-bridge OP_LETSENCRYPT_DOMAIN=""
+kubectl set env deploy/op-scim-bridge OP_TLS_DOMAIN=""
 ```
 
 Modify [`op-scim-service.yaml`](./op-scim-service.yaml) to use the alternate `http` port for the Service as noted within the manifest. Traffic from your TLS endpoint should be directed to this port (80, by default). If SCIM bridge has already been deployed, apply the amended Service manifest:
@@ -249,6 +253,15 @@ kubectl apply -f ./op-scim-service.yaml
 ```
 
 In this configuration, 1Password SCIM bridge will listen for unencrypted traffic on the `http` port of the Pod.
+
+#### Manually-Provided Key/Certificate
+
+Alternatively, you can create new secrets containing your key and certificate files, which can then be used by the SCIM bridge. This will also disable Let's Encrypt functionality.
+
+```bash
+kubectl create secret generic tls-key --from-file=scimsession=/path/to/key.pem
+kubectl create secret generic tls-certificate --from-file=scimsession=/path/to/cert.pem
+```
 
 ### External Redis
 

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -4,16 +4,22 @@ metadata:
   name: op-scim-configmap
 data:
   # Set this to the FQDN you've selected for your SCIM Bridge deployment
-  OP_LETSENCRYPT_DOMAIN: ""
+  # this will enable the complimentary LetsEncrypt challenge server if OP_TLS_CERT_FILE and OP_TLS_KEY_FILE are not set (or valid)
+  OP_TLS_DOMAIN: ""
   # (advanced) only change the options below if you need to
   OP_REDIS_URL: "redis://op-scim-redis:6379"
-  OP_SESSION: "/secrets/scimsession"
   OP_PRETTY_LOGS: "0"
   OP_DEBUG: "0"
   OP_TRACE: "0"
   OP_PING_SERVER: "0"
+  OP_SESSION: "/secrets/scimsession"
+  # OP_TLS_KEY_FILE and OP_TLS_CERT_FILE define the path of a valid SSL key/cert files
+  # if not present, Let's Encrypt will be used to acquire a TLS certificate
+  # NOTE: both of these variables must be defined together to work as expected
+  OP_TLS_KEY_FILE: "/secrets/tls-key"
+  OP_TLS_CERT_FILE: "/secrets/tls-certificate"
   # (optional) uncomment this line to change the email that is used when Let's Encrypt issues your SCIM bridge a certificate
-  # default: "1pw@[OP_LETSENCRYPT_DOMAIN]"
+  # default: "1pw@[OP_TLS_DOMAIN]"
   #OP_LETSENCRYPT_EMAIL: "1pw@example.com"
   # (Workspace Beta) these settings are specific to those participating in the Google Workspace provisioning beta
   OP_WORKSPACE_CREDENTIALS: "/secrets/workspace-credentials.json"

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: op-scim-bridge
-          image: 1password/scim:v2.7.3
+          image: 1password/scim:v2.7.4
           ports:
             # HTTPS port (external TCP traffic should be forwarded to this port by default)
             - name: https


### PR DESCRIPTION
Bumps to v2.7.4, and introduces the `OP_TLS_KEY_FILE` and `OP_TLS_CERT_FILE` environment variables. It also changes `OP_LETSENCRYPT_DOMAIN` to `OP_TLS_DOMAIN`, and updates documentation where appropriate.