### PR TITLE
Fix FTL in v2.7.4 and use TLS Secret type for custom certs

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -282,11 +282,24 @@ In this configuration, 1Password SCIM bridge will listen for unencrypted traffic
 
 #### Manually-Provided Key/Certificate
 
-Alternatively, you can create new secrets containing your key and certificate files, which can then be used by the SCIM bridge. This will also disable Let's Encrypt functionality.
+Alternatively, you can create a TLS Secret containing your key and certificate files, which can then be used by your SCIM bridge. This will also disable Let's Encrypt functionality.
+
+Assuming these files exist in the working directory, create the Secret and set the `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` variables to redeploy SCIM bridge using your certificate:
 
 ```bash
 kubectl create secret tls op-scim-tls --cert=./certificate.pem --key=./key.pem
+kubectl set env deploy op-scim-bridge \
+  OP_TLS_CERT_FILE="/secrets/tls.crt" \
+  OP_TLS_KEY_FILE="/secrets/tls.key"
 ```
+
+> **Note**
+>
+> If your certificate and key files are located elsewhere or have different names, replace `./certificate.pem` and `./key.pem` with the paths to these files, i.e.:
+>
+> ```sh
+> kubectl create secret tls op-scim-tls --cert=path/to/cert/file --key=path/to/key/file
+> ```
 
 ### External Redis
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -285,8 +285,7 @@ In this configuration, 1Password SCIM bridge will listen for unencrypted traffic
 Alternatively, you can create new secrets containing your key and certificate files, which can then be used by the SCIM bridge. This will also disable Let's Encrypt functionality.
 
 ```bash
-kubectl create secret generic tls-key --from-file=scimsession=/path/to/key.pem
-kubectl create secret generic tls-certificate --from-file=scimsession=/path/to/cert.pem
+kubectl create secret tls op-scim-tls --cert=./certificate.pem --key=./key.pem
 ```
 
 ### External Redis

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -16,8 +16,8 @@ data:
   # OP_TLS_KEY_FILE and OP_TLS_CERT_FILE define the path of a valid SSL key/cert files
   # if not present, Let's Encrypt will be used to acquire a TLS certificate
   # NOTE: both of these variables must be defined together to work as expected
-  OP_TLS_KEY_FILE: "/secrets/tls.key"
-  OP_TLS_CERT_FILE: "/secrets/tls.crt"
+  #OP_TLS_KEY_FILE: "/secrets/tls.key"
+  #OP_TLS_CERT_FILE: "/secrets/tls.crt"
   # (optional) uncomment this line to change the email that is used when Let's Encrypt issues your SCIM bridge a certificate
   # default: "1pw@[OP_TLS_DOMAIN]"
   #OP_LETSENCRYPT_EMAIL: "1pw@example.com"

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -16,8 +16,8 @@ data:
   # OP_TLS_KEY_FILE and OP_TLS_CERT_FILE define the path of a valid SSL key/cert files
   # if not present, Let's Encrypt will be used to acquire a TLS certificate
   # NOTE: both of these variables must be defined together to work as expected
-  OP_TLS_KEY_FILE: "/secrets/tls-key"
-  OP_TLS_CERT_FILE: "/secrets/tls-certificate"
+  OP_TLS_KEY_FILE: "/secrets/tls.key"
+  OP_TLS_CERT_FILE: "/secrets/tls.crt"
   # (optional) uncomment this line to change the email that is used when Let's Encrypt issues your SCIM bridge a certificate
   # default: "1pw@[OP_TLS_DOMAIN]"
   #OP_LETSENCRYPT_EMAIL: "1pw@example.com"

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -48,3 +48,11 @@ spec:
           - secret:
               name: workspace-settings  
               optional: true
+          - secret:
+              name: op-scim-tls
+              optional: true
+              items:
+                - key: tls.crt
+                  path: tls.crt
+                - key: tls.key
+                  path: tls.key


### PR DESCRIPTION
This PR fixes #229, and projects the certificate and key files into the container (this was previously missing from the Deployment spec).

It also uses a [TLS Secret type](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) for the Secret where the certificate and key files are stored.

Finally, it amends the instructions to re-enable a custom cert by setting the `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` environment variables using `kubectl`.