### PR TITLE
Force type of env var into string

### DIFF
--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -29,7 +29,7 @@
       },
       {
         "name": "OP_CONFIRMATION_INTERVAL",
-        "value": 300
+        "value": "300"
       }
     ],
     "secrets": [


### PR DESCRIPTION
The expected value type is string, not number. Keeping this as a number throws the following error when running a `terraform plan` or `terraform apply`

```
╷
│ Error: ECS Task Definition container_definitions is invalid: Error decoding JSON: json: cannot unmarshal number into Go struct field KeyValuePair.Environment.Value of type string
│
│   with aws_ecs_task_definition.op_scim_bridge,
│   on main.tf line 136, in resource "aws_ecs_task_definition" "op_scim_bridge":
│  136:   container_definitions = jsonencode(local.container_definitions)
│
╵
```