### PR TITLE
246 docker swarm self managed tls reverts to letsencrypt Fix

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -125,7 +125,7 @@ docker stack deploy -c docker-compose.yml -c gw-docker-compose.yml op-scim
 ```
 Learn more about [connecting Google Workspace to 1Password SCIM Bridge](https://support.1password.com/scim-google-workspace/).
   
-### Self-managed TLS for Docker Swarm
+### Self managed TLS for Docker Swarm
 
 Provide your own key and cert files to the deployment as secrets, which disables Let's Encrypt functionality. In order to utilize self managed TLS key and certificate files, you need to define these as secrets using the following commands and And finally, use `docker stack` to deploy:
 
@@ -243,7 +243,7 @@ After 2-3 minutes, the bridge should come back online with the latest version.
 
 The following options are available for advanced or custom deployments. Unless you have a specific need, these options do not need to be modified.
 
-* `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE`: These two variables can be set to the paths of a key file and certificate file secrets, which will disable Let's Encrypt functionality, causing the SCIM bridge to use your own manually-defined certificate when `OP_TLS_DOMAIN` is also defined. This is only supported with Docker Swarm, not Docker Compose. Note the additional steps above for enabling this feature.
+* `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE`: These two variables can be set to the paths of a key file and certificate file secrets, which will disable Let's Encrypt functionality, causing the SCIM bridge to use your own manually-defined certificate when `OP_TLS_DOMAIN` is also defined. This is only supported with Docker Swarm, not Docker Compose. Note the additional steps above in the [manual self managed TLS section](#Self-managed-TLS-for-Docker-Swarm) for enabling this feature.
 * `OP_PORT`: When `OP_TLS_DOMAIN` is set to blank, you can use `OP_PORT` to change the default port from 3002 to one you choose.
 * `OP_REDIS_URL`: You can specify a `redis://` or `rediss://` (for TLS) URL here to point towards a different Redis host. You can then remove the sections in `docker-compose.yml` that refer to Redis to not deploy that container. Redis is still required for the SCIM bridge to function.
 * `OP_PRETTY_LOGS`: You can set this to `1` if you'd like the SCIM bridge to output logs in a human-readable format. This can be helpful if you aren't planning on doing custom log ingestion in your environment.

--- a/docker/README.md
+++ b/docker/README.md
@@ -126,17 +126,19 @@ Learn more about [connecting Google Workspace to 1Password SCIM Bridge](https://
   
 ### Self-managed TLS for Docker Swarm
 
-Providing your own key and cert files to the deployment as secrets, which disables Let's Encrypt functionality. In order to utilize self managed TLS key and certificate files, you need to define these as secrets using the following commands and uncomment sections of both the scim.env and docker-compose.yml
+Providing your own key and cert files to the deployment as secrets, which disables Let's Encrypt functionality. In order to utilize self managed TLS key and certificate files, you need to define these as secrets using the following commands and And finally, use `docker stack` to deploy:
 
 ```bash
 cat /path/to/private.key | docker secret create op-tls-key -
 cat /path/to/cert.crt | docker secret create op-tls-crt -
 ```
-Open the `scim.env` in your preferred text editor and uncomment the `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` lines. 
 
-Edit the `docker-compose.yml` to uncomment the scim service secret section for `op-tls-key` and `op-tls-crt`. There is also a section to uncomment in the stack deployment section regarding the `op-tls-key` and `op-tls-crt` secrets. 
+Use `docker stack` to deploy:
 
-Perform the normal deployment commands above to either update your existing stack or create the new stack. 
+``` bash
+# deploy your Stack with self-managed TLS using Docker Secrets
+docker stack deploy -c docker-compose.yml -c docker.tls.yml op-scim
+```
 
 ### Docker Compose manual deployment
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,8 @@
 - [Step 3: Deploy 1Password SCIM Bridge](#step-3-deploy-1password-scim-bridge)
 - [Step 4: Test the SCIM bridge](#step-4-test-the-scim-bridge)
 - [Step 5: Connect your identity provider](#step-5-connect-your-identity-provider)
-- [Update your SCIM Bridge](#update-your-scim-bridge)
+- [Update your SCIM bridge](#update-your-scim-bridge)
+- [Advanced: Manual SCIM bridge deployment](#Advanced-Manual-deployment)
 - [Appendix: Advanced `scim.env` options](#appendix-advanced-scimenv-options)
 - [Appendix: Generate `scim.env` on Windows](#appendix-generate-scimenv-on-windows)
 
@@ -61,7 +62,7 @@ To deploy with Docker Compose, you'll need Docker Desktop set up either locally 
 
 <hr>
 
-## Advanced: Manual deployment
+## Advanced Manual deployment
 
 <details>
 <summary>How to manually deploy 1Password SCIM Bridge</summary>
@@ -242,7 +243,7 @@ After 2-3 minutes, the bridge should come back online with the latest version.
 
 The following options are available for advanced or custom deployments. Unless you have a specific need, these options do not need to be modified.
 
-* `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE`: These two variables can be set to the paths of a key file and certificate file, which will disable Let's Encrypt functionality, causing the SCIM bridge to use your own manually-defined certificate when `OP_TLS_DOMAIN` is also defined. This is only supported with Docker Swarm, not Docker Compose. Note the additional steps above for enabling this feature.
+* `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE`: These two variables can be set to the paths of a key file and certificate file secrets, which will disable Let's Encrypt functionality, causing the SCIM bridge to use your own manually-defined certificate when `OP_TLS_DOMAIN` is also defined. This is only supported with Docker Swarm, not Docker Compose. Note the additional steps above for enabling this feature.
 * `OP_PORT`: When `OP_TLS_DOMAIN` is set to blank, you can use `OP_PORT` to change the default port from 3002 to one you choose.
 * `OP_REDIS_URL`: You can specify a `redis://` or `rediss://` (for TLS) URL here to point towards a different Redis host. You can then remove the sections in `docker-compose.yml` that refer to Redis to not deploy that container. Redis is still required for the SCIM bridge to function.
 * `OP_PRETTY_LOGS`: You can set this to `1` if you'd like the SCIM bridge to output logs in a human-readable format. This can be helpful if you aren't planning on doing custom log ingestion in your environment.

--- a/docker/README.md
+++ b/docker/README.md
@@ -121,6 +121,19 @@ Alternate Google Workspace stack deployment command:
 docker stack deploy -c docker-compose.yml -c gw-docker-compose.yml op-scim
 ```
 
+### Self-managed TLS for Docker Swarm
+
+Providing your own key and cert files to the deployment as secrets, which disables Let's Encrypt functionality. In order to utilize self managed TLS key and certificate files, you need to define these as secrets using the following commands and uncomment sections of both the scim.env and docker-compose.yml
+
+```bash
+cat /path/to/private.key | docker secret create op-tls-key -
+cat /path/to/cert.crt | docker secret create op-tls-crt -
+```
+Open the `scim.env` in your preferred text editor and uncomment the `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` lines.
+Edit the `docker-compose.yml` to uncomment the scim service secret section for op-tls-key and op-tls-crt. Also uncomment the stack deployment section regarding the op-tls-key and op-tls-crt secrets.
+Perform the normal deployment commands above to either update your existing stack or create the new stack. 
+
+
 ### Docker Compose
 
 When using Docker Compose, you can create the environment variable `OP_SESSION` manually by doing the following:
@@ -147,7 +160,7 @@ Next, to create the necessary environment variables for Google Workspace:
 # enter the compose directory (if you aren’t already in it)
 cd scim-examples/docker/compose/
 # this is the path of the JSON file you edited in the paragraph above
-wORKSPACE_SETTINGS=$(cat /path/to/workspace_settings.json | base64 | tr -d "\n")
+WORKSPACE_SETTINGS=$(cat /path/to/workspace_settings.json | base64 | tr -d "\n")
 sed -i '' -e "s/OP_WORKSPACE_SETTINGS=$/OP_WORKSPACE_SETTINGS=$WORKSPACE_SETTINGS/" ./scim.env
 # replace <google keyfile> with the name of the file Google generated for your Google Service Account
 GOOGLE_CREDENTIALS=$(cat /path/to/<google keyfile>.json | base64 | tr -d "\n")
@@ -221,7 +234,7 @@ Unless you have customized your Redis deployment, there shouldn’t be any actio
 
 The following options are available for advanced or custom deployments. Unless you have a specific need, these options do not need to be modified.
 
-* `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` - these two variables can be set to the paths of a key file and certificate file, which then disables Let's Encrypt functionality, causing the SCIM bridge to utilize your own manually-defined certificate when `OP_TLS_DOMAIN` is also defined. Note that this is only supported under Docker Swarm, not under Docker Compose.
+* `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` - these two variables can be uncommented to enable self-managed TLS using cert and key secrets, which then disables Let's Encrypt functionality, causing the SCIM bridge to utilize your own manually-defined certificate when `OP_TLS_DOMAIN` is also defined. Note that this is only supported under Docker Swarm, not under Docker Compose. Note the additional steps above for enabling this feature.
 * `OP_PORT` - when `OP_TLS_DOMAIN` is set to blank, you can use `OP_PORT` to change the default port from 3002 to one of your choosing.
 * `OP_REDIS_URL` - you can specify `redis://` or `rediss://` (for TLS) URL here to point towards an alternative Redis host. You can then strip out the sections in `docker-compose.yml` that refer to Redis to not deploy that container. Note that Redis is still required for the SCIM bridge to function.
 * `OP_PRETTY_LOGS` - can be set to `1` if you would like the SCIM bridge to output logs in a human-readable format. This can be helpful if you aren’t planning on doing custom log ingestion in your environment.

--- a/docker/README.md
+++ b/docker/README.md
@@ -126,7 +126,7 @@ Learn more about [connecting Google Workspace to 1Password SCIM Bridge](https://
   
 ### Self-managed TLS for Docker Swarm
 
-Providing your own key and cert files to the deployment as secrets, which disables Let's Encrypt functionality. In order to utilize self managed TLS key and certificate files, you need to define these as secrets using the following commands and And finally, use `docker stack` to deploy:
+Provide your own key and cert files to the deployment as secrets, which disables Let's Encrypt functionality. In order to utilize self managed TLS key and certificate files, you need to define these as secrets using the following commands and And finally, use `docker stack` to deploy:
 
 ```bash
 cat /path/to/private.key | docker secret create op-tls-key -
@@ -138,6 +138,11 @@ Use `docker stack` to deploy:
 ``` bash
 # deploy your Stack with self-managed TLS using Docker Secrets
 docker stack deploy -c docker-compose.yml -c docker.tls.yml op-scim
+```
+
+``` bash
+# (optional) view the service logs
+docker service logs --raw -f op-scim_scim
 ```
 
 ### Docker Compose manual deployment

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,7 +132,11 @@ Providing your own key and cert files to the deployment as secrets, which disabl
 cat /path/to/private.key | docker secret create op-tls-key -
 cat /path/to/cert.crt | docker secret create op-tls-crt -
 ```
-Open the `scim.env` in your preferred text editor and uncomment the `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` lines. Edit the `docker-compose.yml` to uncomment the scim service secret section for op-tls-key and op-tls-crt. Also uncomment the stack deployment section regarding the op-tls-key and op-tls-crt secrets. Perform the normal deployment commands above to either update your existing stack or create the new stack. 
+Open the `scim.env` in your preferred text editor and uncomment the `OP_TLS_CERT_FILE` and `OP_TLS_KEY_FILE` lines. 
+
+Edit the `docker-compose.yml` to uncomment the scim service secret section for `op-tls-key` and `op-tls-crt`. There is also a section to uncomment in the stack deployment section regarding the `op-tls-key` and `op-tls-crt` secrets. 
+
+Perform the normal deployment commands above to either update your existing stack or create the new stack. 
 
 ### Docker Compose manual deployment
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -83,7 +83,7 @@ To use Docker Swarm to deploy, you’ll want to have run `docker swarm init` or 
 
 Unlike Docker Compose, you won’t need to set the `OP_SESSION` variable in `scim.env`, as we’ll be using Docker Secrets to store the `scimsession` file.
 
-You’ll still need to set the environment variable `OP_TLS_DOMAIN` within `scim.env` to the URL you selected during [PREPARATION.md](/PREPARATION.md). Open that in your preferred text editor and change `OP_TLS_DOMAIN` to that domain name.
+You’ll still need to set the environment variable `OP_TLS_DOMAIN` within `scim.env` to the URL you selected during [PREPARATION.md](/PREPARATION.md). Open that in your preferred text editor and change `OP_TLS_DOMAIN` to that domain name. This is also needs to be set for self-managed TLS Docker Swarm deployment.
 
 ### Information for Google Workspace as your Identity Provider (IdP)
 If you’re using Google Workspace as your identity provider for provisioning, you will need to set up some additional secrets to use this functionality as detailed below. Refer to our complete Google Workspace provisioning documentation for more complete information, https://support.1password.com/scim-google-workspace. 

--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -18,18 +18,6 @@ services:
         uid: "999"
         gid: "999"
         mode: 0440
-      ## Uncomment the section below to utilize your own self-managed TLS cert and key secrets instead of utlizing Let's Encrypt
-      ## Be sure to also remove the comments from the secrets section below and uncomment the OP_TLS_KEY_FILE and OP_TLS_CERT_FILE in scim.env
-      # - source: op-tls-key
-      #   target: op-tls-key
-      #   uid: "999"
-      #   gid: "999"
-      #   mode: 0440
-      # - source: op-tls-crt
-      #   target: op-tls-crt
-      #   uid: "999"
-      #   gid: "999"
-      #   mode: 0440
       ## Uncomment this section for DNS01 secret
       # - source: dns01-config
       #   target: dns01-config
@@ -54,8 +42,3 @@ networks:
 secrets:
   scimsession:
     external: true
-  # Be sure to also remove the comments from the secrets section above for the scim service
-  # op-tls-key:
-  #   external: true
-  # op-tls-crt:
-  #   external: true

--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -9,15 +9,28 @@ services:
     networks:
       - op-scim
     ports:
-      - "80:8080"
+      #- "80:8080"
       - "443:8443"
-      - "3002:3002"
+      #- "3002:3002"
     secrets:
       - source: scimsession
         target: scimsession
         uid: "999"
         gid: "999"
         mode: 0440
+      ## Uncomment the section below to utilize your own self-managed TLS cert and key secrets instead of utlizing Let's Encrypt
+      ## Be sure to also remove the comments from the secrets section below and uncomment the OP_TLS_KEY_FILE and OP_TLS_CERT_FILE in scim.env
+      # - source: op-tls-key
+      #   target: op-tls-key
+      #   uid: "999"
+      #   gid: "999"
+      #   mode: 0440
+      # - source: op-tls-crt
+      #   target: op-tls-crt
+      #   uid: "999"
+      #   gid: "999"
+      #   mode: 0440
+      ## Uncomment this section for DNS01 secret
       # - source: dns01-config
       #   target: dns01-config
       #   uid: "999"
@@ -41,3 +54,8 @@ networks:
 secrets:
   scimsession:
     external: true
+  # Be sure to also remove the comments from the secrets section above for the scim service
+  # op-tls-key:
+  #   external: true
+  # op-tls-crt:
+  #   external: true

--- a/docker/swarm/docker.tls.yml
+++ b/docker/swarm/docker.tls.yml
@@ -1,3 +1,4 @@
+version: "3.3"
 services:
   scim:
     secrets:

--- a/docker/swarm/docker.tls.yml
+++ b/docker/swarm/docker.tls.yml
@@ -1,0 +1,21 @@
+services:
+  scim:
+    secrets:
+      - source: op-tls-key
+        target: op-tls-key
+        uid: "999"
+        gid: "999"
+        mode: 0440
+      - source: op-tls-crt
+        target: op-tls-crt
+        uid: "999"
+        gid: "999"
+        mode: 0440
+    environment:
+      - OP_TLS_KEY_FILE=/run/secrets/op-tls-key
+      - OP_TLS_CERT_FILE=/run/secrets/op-tls-crt
+secrets:
+  op-tls-key:
+    external: true
+  op-tls-crt:
+    external: true

--- a/docker/swarm/scim.env
+++ b/docker/swarm/scim.env
@@ -8,13 +8,17 @@ OP_TLS_DOMAIN=op-scim.example.com
 #OP_TLS_DOMAIN=
 
 # (ADVANCED) the options below aren't usually necessary during routine deployments, but can be used if you have a specific need
+
+# Self-managed TLS using cert and key secrets by uncommenting the OP_TLS_KEY_FILE and OP_TLS_CERT_FILE
+# NOTE: these secrets are defined in the docker-compose.yaml
+
 # OP_TLS_KEY_FILE defines the path of a valid SSL key file
-# NOTE: this must be combined with OP_TLS_CERT_FILE and be valid to work as expected
-#OP_TLS_KEY_FILE=/path/to/key.pem
+# NOTE: this must be combined with OP_TLS_CERT_FILE and be valid to work as expected, stored as a Docker Swarm Secret
+#OP_TLS_KEY_FILE=/run/secrets/op-tls-key
 
 # OP_TLS_CERT_FILE defines the path of a valid SSL certificate file
-# NOTE: this must be combined with OP_TLS_KEY_FILE and be valid to work as expected
-#OP_TLS_CERT_FILE=/path/to/cert.pem
+# NOTE: this must be combined with OP_TLS_KEY_FILE and be valid to work as expected, stored as a Docker Swarm Secret
+#OP_TLS_CERT_FILE=/run/secrets/op-tls-crt
 
 # OP_PORT can be used to override the port number when the SCIM Bridge is running on port 3002 (when OP_TLS_DOMAIN is blank)
 #OP_PORT=3002
@@ -42,7 +46,7 @@ OP_REDIS_URL=redis://redis:6379
 
 # OP_DNS_CHALLENGE_CONFIG_FILE sets the path to a Let's Encrypt DNS-01 configuration file
 # Ensure to also uncomment the dns01-config secret section in the docker-compose.yml
-# OP_DNS_CHALLENGE_CONFIG_FILE=/run/secrets/dns01-config
+#OP_DNS_CHALLENGE_CONFIG_FILE=/run/secrets/dns01-config
 
 # OP_SESSION can be either the base64-encoded string of a `scimsession` file, or it can be the path to a `scimsession` file (as in a Docker Swarm Secret)
 # examples: "OP_SESSION=abcdefg123456", "OP_SESSION=/path/to/scimsession"


### PR DESCRIPTION
Better handling of certificate files for self-managed TLS deployment option