### PR TITLE
Codify deprecation process and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ After you've read the preparation guide, refer to the deployment example for you
 
 ### Beta deployment
 
-These are beta versions of 1Password SCIM Bridge deployments and components. These deployments *should* work, but aren't guaranteed and will change in the future.
+These are beta versions of 1Password SCIM Bridge deployments and components. These deployments _should_ work, but aren't guaranteed and will change in the future.
 
 - ✨ **NEW** [AWS with CloudFormation](/beta/aws-ecsfargate-cfn)
 - ✨ **NEW** [Azure Container App](/beta/azure-container-apps)
@@ -38,7 +38,12 @@ These are beta versions of 1Password SCIM Bridge deployments and components. The
 
 A list of recently-deprecated deployments can be found in [`/deprecated`](./deprecated/). At the time of deprecation, these deployments were still fully functional, but will no longer be updated and will be deleted three months after deprecation.
 
-> 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM bridge itself, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
+> 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM Bridge itself, or a specific version of the 1Password SCIM Bridge. For information about the latest 1Password SCIM Bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
+
+| Deployment                                                           | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                              |
+| -------------------------------------------------------------------- | ---------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [aws-ec2-terraform](./deprecated/aws-terraform/)                     | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](./aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/) |
+| [DigitalOcean App Platform](./deprecated/digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](./beta/do-app-platform-op-cli/) or [Azure Container Apps](./beta/azure-container-apps/) |
 
 ### Deprecation schedule
 
@@ -46,8 +51,7 @@ When a deployment method is deprecated, we will simultaneously post a notice to 
 
 Deprecated deployments will remain in [`/deprecated`](./deprecated/) for **three months**, after which time they will be deleted. The deletion date of deprecated deployments will be posted in [`/deprecated/README.md`](./deprecated/README.md).
 
-Where possible, we will provide suggested alternatives in [`/deprecated/README.md`](./deprecated/README.md). 
-
+Where possible, we will provide suggested alternatives in [`/deprecated/README.md`](./deprecated/README.md).
 
 ## Get help
 

--- a/README.md
+++ b/README.md
@@ -34,22 +34,17 @@ These are beta versions of 1Password SCIM Bridge deployments and components. The
 - [Google Workspace settings](/beta/workspace-settings.json)
 - [Google Workspace module for Terraform](/beta/aws-terraform-gw/)
 
-## Deprecated deployments
+## Deprecated deployment methods
 
-A list of recently-deprecated deployments can be found in [`/deprecated`](./deprecated/). At the time of deprecation, these deployments were still fully functional, but will no longer be updated and will be deleted three months after deprecation.
+A list of recently-deprecated deployments can be found in [`/deprecated`](./deprecated/). At the time of deprecation, these deployments were fully functional, but will no longer be updated.
 
-> 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM Bridge itself, or a specific version of the 1Password SCIM Bridge. For information about the latest 1Password SCIM Bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
-
-| Deployment                                                           | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                              |
-| -------------------------------------------------------------------- | ---------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| [aws-ec2-terraform](./deprecated/aws-terraform/)                     | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](./aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/) |
-| [DigitalOcean App Platform](./deprecated/digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](./beta/do-app-platform-op-cli/) or [Azure Container Apps](./beta/azure-container-apps/) |
+* [**List of deprecated deployment methods**](./deprecated/README.md#deprecated-deployments)
 
 ### Deprecation schedule
 
-When a deployment method is deprecated, we will simultaneously post a notice to this README and move the corresponding example to [`/deprecated`](./deprecated/).
+When a deployment method is deprecated, we will simultaneously append a deprecation notice to the deployment name listed in this README and move all files associated with the deployment method to [`/deprecated`](./deprecated/). 
 
-Deprecated deployments will remain in [`/deprecated`](./deprecated/) for **three months**, after which time they will be deleted. The deletion date of deprecated deployments will be posted in [`/deprecated/README.md`](./deprecated/README.md).
+Deprecated deployments will remain in [`/deprecated`](./deprecated/) for approximately **three months**, after which time they will be deleted. The deletion date of deprecated deployments will be posted in [`/deprecated/README.md`](./deprecated/README.md).
 
 Where possible, we will provide suggested alternatives in [`/deprecated/README.md`](./deprecated/README.md).
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,20 @@ These are beta versions of 1Password SCIM Bridge deployments and components. The
 - [Google Workspace settings](/beta/workspace-settings.json)
 - [Google Workspace module for Terraform](/beta/aws-terraform-gw/)
 
-### Deprecated deployments
+## Deprecated deployments
 
-The following are deprecated 1Password SCIM Bridge deployments. At the time of deprecation, these deployments were still fully functional, but may no longer be updated and will eventually be removed.
+A list of recently-deprecated deployments can be found in [`/deprecated`](./deprecated/). At the time of deprecation, these deployments were still fully functional, but will no longer be updated and will be deleted three months after deprecation.
 
-- [AWS EC2 with terraform](/deprecated/aws-terraform/)
-- [DigitalOcean App Platform](/deprecated/digitalocean-app-platform/)
+> 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM bridge itself, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
+
+### Deprecation schedule
+
+When a deployment method is deprecated, we will simultaneously post a notice to this README and move the corresponding example to [`/deprecated`](./deprecated/).
+
+Deprecated deployments will remain in [`/deprecated`](./deprecated/) for **three months**, after which time they will be deleted. The deletion date of deprecated deployments will be posted in [`/deprecated/README.md`](./deprecated/README.md).
+
+Where possible, we will provide suggested alternatives in [`/deprecated/README.md`](./deprecated/README.md). 
+
 
 ## Get help
 

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -11,40 +11,40 @@ This folder contains 1Password SCIM Bridge deployment methods that have been dep
 | [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
 | [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
 
-
 ### No longer supported
-The following is a list of deployment methods that are no longer supported and were removed from the repository upon expiration of their deperecation period. These deployment methods are no longer supported. If you previously depended on one of these deployment methods, consider one of the suggested alternatives. 
 
-| Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
-| --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
-| [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
+The following is a list of deployment methods that are no longer supported and were removed from the repository upon expiration of their deperecation period. These deployment methods are no longer supported. If you previously depended on one of these deployment methods, consider one of the suggested alternatives.
 
+| Deployment | Deprecation Date | Deletion Date | Suggested Alternative |
+| ---------- | ---------------- | ------------- | --------------------- |
+| -          | -                | -             | -                     |
 
 ## Process for deprecating deployment methods
 
 Generally speaking we try to improve existing deployment methods or create additional deployment methods. However, where updating existing deployment methods is not feasible, we will resort to deprecation.
 
 There are many reasons a deployment method may be slated for deprecation. A deployment method may be deprecated for a variety of reasons, along or in combination. Common reasons a deployment method may be deprecated include:
-* It relies on tooling, utilities, or technologies that have themselves been deprecated or where new versions of the utility/technology introduced breaking changes.
-* It is complex, unreliable, inflexible, or costly, and often leads to poor experiences. A similar deployment method on the same platform or leveraging similar technologies may or may not exist as a replacement. 
+
+- It relies on tooling, utilities, or technologies that have themselves been deprecated or where new versions of the utility/technology introduced breaking changes.
+- It is complex, unreliable, inflexible, or costly, and often leads to poor experiences. A similar deployment method on the same platform or leveraging similar technologies may or may not exist as a replacement.
 
 ### Steps to deprecate a deployment method
-All deprecations will take place through a merge request which must be approved by a 1Password employee.  
 
-1. Identify a candidate for deprecation using the [above criteria](#process-for-deprecating-deployment-methods) along with insights from Integrations Support, your experience, and changes to dependencies, required utilities, host platforms, and technologies.  
-    * There are no hard and fast rules here, and no single criteria. When making deprecation decisions, the focus should be on ensuring the best possible experience for 1Password SCIM Bridge users. 
+All deprecations will take place through a merge request which must be approved by a 1Password employee.
+
+1. Identify a candidate for deprecation using the [above criteria](#process-for-deprecating-deployment-methods) along with insights from Integrations Support, your experience, and changes to dependencies, required utilities, host platforms, and technologies.
+   - There are no hard and fast rules here, and no single criteria. When making deprecation decisions, the focus should be on ensuring the best possible experience for 1Password SCIM Bridge users.
 2. Open a new branch with a name conforming to `deprecate/<deployment-method-name>`
 3. Move all assets related to the deployment method to `./deprecated/<deployment-method-name>`
 4. Update READMEs
-    * To the [Deprecated Deployments table](../deprecated/README.md#deployments-list) in `deprecated/README.md`:
-      * Add the name and link to the updated path of the deployment in `/deprecated`.
-      * Set `Deprecation Date` to be the current date (to be updated at merge time to the date of the merge).
-      * Set `Deletion Date` to be approximately three months from the deprecation date (considering weekends, holidays, or other events). This may or may not be updated along with the deprecation date at merge time.  
-    * To the [README in the repository root](../README.md) add:
-      * Suffix the name of the deployment in the list with `**(⚠️ Deprecated)**`. 
-      * Update the URL of the linked text point to the new path of the deployment in `/deprecated`.
+   - To the [Deprecated Deployments table](../deprecated/README.md#deployments-list) in `deprecated/README.md`:
+     - Add the name and link to the updated path of the deployment in `/deprecated`.
+     - Set `Deprecation Date` to be the current date (to be updated at merge time to the date of the merge).
+     - Set `Deletion Date` to be approximately three months from the deprecation date (considering weekends, holidays, or other events). This may or may not be updated along with the deprecation date at merge time.
+   - To the [README in the repository root](../README.md) add:
+     - Suffix the name of the deployment in the list with `**(⚠️ Deprecated)**`.
+     - Update the URL of the linked text point to the new path of the deployment in `/deprecated`.
 5. Put your MR up for review and approval. In your MR, please include:
-    * Justification for the deprecation.
-    * Why updating or improving the deployment method is not possible or practical.
-    * Suggestions for existing alternatives, if any. 
+   - Justification for the deprecation.
+   - Why updating or improving the deployment method is not possible or practical.
+   - Suggestions for existing alternatives, if any.

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -1,8 +1,11 @@
 # Deprecated Deployments
 
-This folder contains deprecated versions of 1Password SCIM bridge deployments. 
+This folder contains 1Password SCIM Bridge deployment methods that have been deprecated. At the time of deprecation, these deployments are still fully functional, but will no longer be updated. 
 
-At the time of deprecation, these deployments are still fully functional, but may no longer be updated and will eventually be removed.
+{% note %}
+**Note:** 💡 Note that it is solely the _deployment method_ that is deprecated, not the 1Password SCIM bridge, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
+{% endnote %}
 
 ## Deployments
- - [aws-terraform](./aws-terraform) (2020-12-21)
+ - [aws-terraform](./aws-terraform) 
+ - [DigitalOcean App Platform](./digitalocean-app-platform/)

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -4,10 +4,47 @@ This folder contains 1Password SCIM Bridge deployment methods that have been dep
 
 > 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM Bridge itself, or a specific version of the 1Password SCIM Bridge. For information about the latest version of 1Password SCIM Bridge, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
 
-## Deployments
+## Deployments list
 
 | Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
 | --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
 | [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
 
+
+### No longer supported
+The following is a list of deployment methods that are no longer supported and were removed from the repository upon expiration of their deperecation period. These deployment methods are no longer supported. If you previously depended on one of these deployment methods, consider one of the suggested alternatives. 
+
+| Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
+| --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
+| [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
+
+
+## Process for deprecating deployment methods
+
+Generally speaking we try to improve existing deployment methods or create additional deployment methods. However, where updating existing deployment methods is not feasible, we will resort to deprecation.
+
+There are many reasons a deployment method may be slated for deprecation. A deployment method may be deprecated for a variety of reasons, along or in combination. Common reasons a deployment method may be deprecated include:
+* It relies on tooling, utilities, or technologies that have themselves been deprecated or where new versions of the utility/technology introduced breaking changes.
+* It is complex, unreliable, inflexible, or costly, and often leads to poor experiences. A similar deployment method on the same platform or leveraging similar technologies may or may not exist as a replacement. 
+
+### Steps to deprecate a deployment method
+All deprecations will take place through a merge request which must be approved by a 1Password employee.  
+
+1. Identify a candidate for deprecation using the [above criteria](#process-for-deprecating-deployment-methods) along with insights from Integrations Support, your experience, and changes to dependencies, required utilities, host platforms, and technologies.  
+    * There are no hard and fast rules here, and no single criteria. When making deprecation decisions, the focus should be on ensuring the best possible experience for 1Password SCIM Bridge users. 
+2. Open a new branch with a name conforming to `deprecate/<deployment-method-name>`
+3. Move all assets related to the deployment method to `./deprecated/<deployment-method-name>`
+4. Update READMEs
+    * To the [Deprecated Deployments table](../deprecated/README.md#deployments-list) in `deprecated/README.md`:
+      * Add the name and link to the updated path of the deployment in `/deprecated`.
+      * Set `Deprecation Date` to be the current date (to be updated at merge time to the date of the merge).
+      * Set `Deletion Date` to be approximately three months from the deprecation date (considering weekends, holidays, or other events). This may or may not be updated along with the deprecation date at merge time.  
+    * To the [README in the repository root](../README.md) add:
+      * Suffix the name of the deployment in the list with `**(⚠️ Deprecated)**`. 
+      * Update the URL of the linked text point to the new path of the deployment in `/deprecated`.
+5. Put your MR up for review and approval. In your MR, please include:
+    * Justification for the deprecation.
+    * Why updating or improving the deployment method is not possible or practical.
+    * Suggestions for existing alternatives, if any. 

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -2,12 +2,12 @@
 
 This folder contains 1Password SCIM Bridge deployment methods that have been deprecated. At the time of deprecation, these deployments are still fully functional, but will no longer be updated.
 
-> 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM bridge itself, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
+> 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM Bridge itself, or a specific version of the 1Password SCIM Bridge. For information about the latest version of 1Password SCIM Bridge, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
 
 ## Deployments
 
 | Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
 | --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/)                                                                       |
+| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
 | [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
 |                                                           |                  |               |

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -1,10 +1,13 @@
 # Deprecated Deployments
 
-This folder contains 1Password SCIM Bridge deployment methods that have been deprecated. At the time of deprecation, these deployments are still fully functional, but will no longer be updated. 
+This folder contains 1Password SCIM Bridge deployment methods that have been deprecated. At the time of deprecation, these deployments are still fully functional, but will no longer be updated.
 
-> 💡 Note that it is solely the _deployment method_ that is deprecated, not the 1Password SCIM bridge, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
-
+> 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM bridge itself, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
 
 ## Deployments
- - [aws-terraform](./aws-terraform) 
- - [DigitalOcean App Platform](./digitalocean-app-platform/)
+
+| Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
+| --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/)                                                                       |
+| [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
+|                                                           |                  |               |

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -10,4 +10,4 @@ This folder contains 1Password SCIM Bridge deployment methods that have been dep
 | --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
 | [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
-|                                                           |                  |               |
+

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -8,18 +8,18 @@ This folder contains 1Password SCIM Bridge deployment methods that have been dep
 
 The following deployment methods are deprecated and will be removed from the repository on or around the Deletion Date.
 
-| Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
-| --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](../beta/aws-ecsfargate-cfn/)  |
-| [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
+| Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                | Deprecation PR                                                |
+| --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](../beta/aws-ecsfargate-cfn/) | [PR#127](https://github.com/1Password/scim-examples/pull/127) |
+| [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) | [PR#222](https://github.com/1Password/scim-examples/pull/222) |
 
 ### Deleted deployment methods
 
 The following is a list of deployment methods that are no longer supported and were removed from the repository upon expiration of their deperecation period. These deployment methods are no longer supported. If you previously depended on one of these deployment methods, consider one of the suggested alternatives.
 
-| Deployment | Deprecation Date | Deletion Date | Suggested Alternative |
-| ---------- | ---------------- | ------------- | --------------------- |
-| -          | -                | -             | -                     |
+| Deployment | Deprecation Date | Deletion Date | Suggested Alternative | Deprecation and Deletion PRs |
+| ---------- | ---------------- | ------------- | --------------------- | ---------------------------- |
+| -          | -                | -             | -                     | -                            |
 
 ## Process for deprecating deployment methods
 
@@ -32,7 +32,7 @@ Common reasons a deployment method may be deprecated include one or more of:
 
 ### Steps to deprecate a deployment method
 
-All deprecations will take place through a merge request and must be approved by a 1Password employee.
+All deprecations will take place through a pull request and must be approved by a 1Password employee.
 
 1. Identify a candidate for deprecation using the [above criteria](#process-for-deprecating-deployment-methods) along with insights from Integrations Support, your experience, and changes to dependencies, required utilities, host platforms, and technologies.
    - There are no hard and fast rules here, and no single criteria. When making deprecation decisions, the focus should be on ensuring the best possible experience for 1Password SCIM Bridge users.
@@ -43,23 +43,25 @@ All deprecations will take place through a merge request and must be approved by
      - Add the name and link to the updated path of the deployment in `/deprecated`
      - Set `Deprecation Date` to be the current date (to be updated at merge time to the date of the merge)
      - Set `Deletion Date` to be approximately three months from the deprecation date (considering weekends, holidays, or other events). This may or may not be updated along with the deprecation date at merge time.
+     - Add link to PR, once known, to the `Deprecation PR` column. 
    - To the [README in the repository root](../README.md) add:
-     - Suffix the name of the deployment in the list with `**(⚠️ Deprecated)**`.
+     - Prefix the name of the deployment in the list with `**(⚠️ Deprecated)**`.
      - Update the URL of the linked text point to the new path of the deployment in `/deprecated`.
-5. Put your MR up for review and approval. In your MR, please include:
+5. Put your PR up for review and approval. In your PR, please include:
    - Justification for the deprecation
    - Why updating or improving the deployment method is not possible or practical
    - Suggestions for existing alternatives, if any
-   - Use internal tooling to set a reminder for both User Lifecycle Developers and Solutions Architects to delete the deprecated method on it's Deletion Date. 
+   - Use internal tooling to set a reminder for both User Lifecycle Developers and Solutions Architects to delete the deprecated method on it's Deletion Date.
 
 ### Steps to delete a deprecated deployment method
 
-Deleting a deprecated deployment that has reached it's Deletion Date will take place through a merge request and must be approved by a 1Password employee. 
+Deleting a deprecated deployment that has reached it's Deletion Date will take place through a pull request and must be approved by a 1Password employee.
 
 1. Open a new branch with a name conforming to `remove/<deployment-method-name>`
-2. On that branch, remove the directories and files associated with that deployment method. 
+2. On that branch, remove the directories and files associated with that deployment method.
 3. Updated READMEs
-    - Remove the deployment method from the [Deprecated deployment method table](README.md#deprecated-deployment-method-list) in `deprecated/README.md` 
-    - Add the deployment to the [Deleted deployment methods](README.md#deleted-deployment-methods) table. 
-    - Remove the deployment method from [README in the repository root](../README.md)
-4. Put your MR up for review and approval. 
+   - Remove the deployment method from the [Deprecated deployment method table](README.md#deprecated-deployment-method-list) in `deprecated/README.md`
+   - Add the deployment to the [Deleted deployment methods](README.md#deleted-deployment-methods) table.
+   - Add link to the PRs used for the original deprecation, and for deletion (once known), to the appropriate column in table. 
+   - Remove the deployment method from [README in the repository root](../README.md)
+4. Put your PR up for review and approval.

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -10,7 +10,7 @@ The following deployment methods are deprecated and will be removed from the rep
 
 | Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
 | --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
+| [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](../beta/aws-ecsfargate-cfn/)  |
 | [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
 
 ### Deleted deployment methods

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -4,7 +4,9 @@ This folder contains 1Password SCIM Bridge deployment methods that have been dep
 
 > 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM Bridge itself, or a specific version of the 1Password SCIM Bridge. For information about the latest version of 1Password SCIM Bridge, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
 
-## Deployments list
+## Deprecated deployment list
+
+The following deployment methods are deprecated and will be removed from the repository on or around the Deletion Date.
 
 | Deployment                                                | Deprecation Date | Deletion Date | Suggested Alternative                                                                                                                |
 | --------------------------------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
@@ -30,7 +32,7 @@ There are many reasons a deployment method may be slated for deprecation. A depl
 
 ### Steps to deprecate a deployment method
 
-All deprecations will take place through a merge request which must be approved by a 1Password employee.
+All deprecations will take place through a merge request and must be approved by a 1Password employee.
 
 1. Identify a candidate for deprecation using the [above criteria](#process-for-deprecating-deployment-methods) along with insights from Integrations Support, your experience, and changes to dependencies, required utilities, host platforms, and technologies.
    - There are no hard and fast rules here, and no single criteria. When making deprecation decisions, the focus should be on ensuring the best possible experience for 1Password SCIM Bridge users.
@@ -38,13 +40,26 @@ All deprecations will take place through a merge request which must be approved 
 3. Move all assets related to the deployment method to `./deprecated/<deployment-method-name>`
 4. Update READMEs
    - To the [Deprecated Deployments table](../deprecated/README.md#deployments-list) in `deprecated/README.md`:
-     - Add the name and link to the updated path of the deployment in `/deprecated`.
-     - Set `Deprecation Date` to be the current date (to be updated at merge time to the date of the merge).
+     - Add the name and link to the updated path of the deployment in `/deprecated`
+     - Set `Deprecation Date` to be the current date (to be updated at merge time to the date of the merge)
      - Set `Deletion Date` to be approximately three months from the deprecation date (considering weekends, holidays, or other events). This may or may not be updated along with the deprecation date at merge time.
    - To the [README in the repository root](../README.md) add:
      - Suffix the name of the deployment in the list with `**(⚠️ Deprecated)**`.
      - Update the URL of the linked text point to the new path of the deployment in `/deprecated`.
 5. Put your MR up for review and approval. In your MR, please include:
-   - Justification for the deprecation.
-   - Why updating or improving the deployment method is not possible or practical.
-   - Suggestions for existing alternatives, if any.
+   - Justification for the deprecation
+   - Why updating or improving the deployment method is not possible or practical
+   - Suggestions for existing alternatives, if any
+   - Use internal tooling to set a reminder for both User Lifecycle Developers and Solutions Architects to delete the deprecated method on it's Deletion Date. 
+
+### Deleting a deprecated deployment
+
+Deleting a deprecated deployment that has reached it's Deletion Date will take place through a merge request and must be approved by a 1Password employee. 
+
+1. Open a new branch with a name conforming to `remove/<deployment-method-name>`
+2. On that branch, remove the directories and files associated with that deployment method. 
+3. Updated READMEs
+    - Remove the deployment method from the [Deprecated Deployments table](../deprecated/README.md#deployments-list) in `deprecated/README.md` 
+    - Add the deployment to the [No longer supported](../deprecated/README.md#no-longer-supported) table. 
+    - Remove the deployment method from [README in the repository root](../README.md)
+4. Put your MR up for review and approval. 

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -4,7 +4,7 @@ This folder contains 1Password SCIM Bridge deployment methods that have been dep
 
 > 💡 **Note** that it is solely the _deployment method_ that is deprecated. Deprecating a deployment method is independent of the 1Password SCIM Bridge itself, or a specific version of the 1Password SCIM Bridge. For information about the latest version of 1Password SCIM Bridge, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
 
-## Deprecated deployment list
+## Deprecated deployment method list
 
 The following deployment methods are deprecated and will be removed from the repository on or around the Deletion Date.
 
@@ -13,7 +13,7 @@ The following deployment methods are deprecated and will be removed from the rep
 | [aws-ec2-terraform](./aws-terraform)                      | 2020-12-21       | 2023-09-14    | [AWS ECS Fargate with Terraform](../aws-ecsfargate-terraform/) or [AWS ECS Fargate with CloudFormation](./beta/aws-ecsfargate-cfn/)  |
 | [DigitalOcean App Platform](./digitalocean-app-platform/) | 2022-12-21       | 2023-09-14    | [Digital Ocean App Platform with `op` CLI](../beta/do-app-platform-op-cli/) or [Azure Container Apps](../beta/azure-container-apps/) |
 
-### No longer supported
+### Deleted deployment methods
 
 The following is a list of deployment methods that are no longer supported and were removed from the repository upon expiration of their deperecation period. These deployment methods are no longer supported. If you previously depended on one of these deployment methods, consider one of the suggested alternatives.
 
@@ -25,10 +25,10 @@ The following is a list of deployment methods that are no longer supported and w
 
 Generally speaking we try to improve existing deployment methods or create additional deployment methods. However, where updating existing deployment methods is not feasible, we will resort to deprecation.
 
-There are many reasons a deployment method may be slated for deprecation. A deployment method may be deprecated for a variety of reasons, along or in combination. Common reasons a deployment method may be deprecated include:
+Common reasons a deployment method may be deprecated include one or more of:
 
 - It relies on tooling, utilities, or technologies that have themselves been deprecated or where new versions of the utility/technology introduced breaking changes.
-- It is complex, unreliable, inflexible, or costly, and often leads to poor experiences. A similar deployment method on the same platform or leveraging similar technologies may or may not exist as a replacement.
+- A superior deployment method using the same or similar technologies on the same or similar platform (if applicable) has been developed.
 
 ### Steps to deprecate a deployment method
 
@@ -39,7 +39,7 @@ All deprecations will take place through a merge request and must be approved by
 2. Open a new branch with a name conforming to `deprecate/<deployment-method-name>`
 3. Move all assets related to the deployment method to `./deprecated/<deployment-method-name>`
 4. Update READMEs
-   - To the [Deprecated Deployments table](../deprecated/README.md#deployments-list) in `deprecated/README.md`:
+   - To the [Deprecated Deployments table](README.md#deprecated-deployment-method-list) in `deprecated/README.md`:
      - Add the name and link to the updated path of the deployment in `/deprecated`
      - Set `Deprecation Date` to be the current date (to be updated at merge time to the date of the merge)
      - Set `Deletion Date` to be approximately three months from the deprecation date (considering weekends, holidays, or other events). This may or may not be updated along with the deprecation date at merge time.
@@ -52,14 +52,14 @@ All deprecations will take place through a merge request and must be approved by
    - Suggestions for existing alternatives, if any
    - Use internal tooling to set a reminder for both User Lifecycle Developers and Solutions Architects to delete the deprecated method on it's Deletion Date. 
 
-### Deleting a deprecated deployment
+### Steps to delete a deprecated deployment method
 
 Deleting a deprecated deployment that has reached it's Deletion Date will take place through a merge request and must be approved by a 1Password employee. 
 
 1. Open a new branch with a name conforming to `remove/<deployment-method-name>`
 2. On that branch, remove the directories and files associated with that deployment method. 
 3. Updated READMEs
-    - Remove the deployment method from the [Deprecated Deployments table](../deprecated/README.md#deployments-list) in `deprecated/README.md` 
-    - Add the deployment to the [No longer supported](../deprecated/README.md#no-longer-supported) table. 
+    - Remove the deployment method from the [Deprecated deployment method table](README.md#deprecated-deployment-method-list) in `deprecated/README.md` 
+    - Add the deployment to the [Deleted deployment methods](README.md#deleted-deployment-methods) table. 
     - Remove the deployment method from [README in the repository root](../README.md)
 4. Put your MR up for review and approval. 

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -2,17 +2,8 @@
 
 This folder contains 1Password SCIM Bridge deployment methods that have been deprecated. At the time of deprecation, these deployments are still fully functional, but will no longer be updated. 
 
-{% note %}
+> 💡 Note that it is solely the _deployment method_ that is deprecated, not the 1Password SCIM bridge, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
 
-**Note:** 💡 Note that it is solely the _deployment method_ that is deprecated, not the 1Password SCIM bridge, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
-
-{% endnote %}
-
-{% note %}
-
-**Note:** Owners and administrators can add outside collaborators to a repository.
-
-{% endnote %}
 
 ## Deployments
  - [aws-terraform](./aws-terraform) 

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -8,6 +8,12 @@ This folder contains 1Password SCIM Bridge deployment methods that have been dep
 
 {% endnote %}
 
+{% note %}
+
+**Note:** Owners and administrators can add outside collaborators to a repository.
+
+{% endnote %}
+
 ## Deployments
  - [aws-terraform](./aws-terraform) 
  - [DigitalOcean App Platform](./digitalocean-app-platform/)

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -3,7 +3,9 @@
 This folder contains 1Password SCIM Bridge deployment methods that have been deprecated. At the time of deprecation, these deployments are still fully functional, but will no longer be updated. 
 
 {% note %}
+
 **Note:** 💡 Note that it is solely the _deployment method_ that is deprecated, not the 1Password SCIM bridge, or a specific version of the 1Password SCIM bridge. For information about the latest SCIM bridge version, please see the [changelog](https://app-updates.agilebits.com/product_history/SCIM).
+
 {% endnote %}
 
 ## Deployments


### PR DESCRIPTION
This PR introduces:
* Improvements to how we document deprecated deployments
* Provides people with a clearly stated process and timeline for deprecated deployments. 

The details
* Deprecated deployments will be moved to `/deprecated` 
* A notice will be posted to both README files in the root and `./deprecated`
* Date of deprecation and date of deletion will be included for each deployment method 
* Deletion will take place 12 weeks after deprecation.  
* Deployments already deprecated as of 2023-08-14 will be deleted in one month (2023-09-14), since both have been deprecated for > 8 months.
