### PR TITLE
Docker beta deployment example improvements

### DIFF
--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -5,7 +5,7 @@ This example describes how to deploy 1Password SCIM Bridge as a stack using [Doc
 ## In this folder
 
 - [`README.md`](./README.md): the document that you are reading. 👋😃
-- [`compose.template.yaml`](./compose.template.yaml): a [Compose specification](https://docs.docker.com/compose/compose-file/) format [Compose file](https://docs.docker.com/compose/compose-file/03-compose-file/) for 1Password SCIM Bridge.
+- [`compose.template.yaml`](./compose.template.yaml): a [Compose Specification](https://docs.docker.com/compose/compose-file/) format [Compose file](https://docs.docker.com/compose/compose-file/03-compose-file/) for 1Password SCIM Bridge.
 - [`compose.gw.yaml`](./compose.gw.yaml): an [override configuration](https://docs.docker.com/compose/multiple-compose-files/merge/) to merge the configuration necessary for customers integrating with Google Workspace.
 - [`redis.conf`](./redis.conf): a [Redis configuration file](https://redis.io/docs/management/config/) to load the Redis cache with the base configuration required for SCIM bridge
 - [`scim.env`](./scim.env): an environment file that can be used to customize the SCIM bridge configuration.
@@ -31,7 +31,6 @@ Before proceeding, you should review the [Preparation Guide](/PREPARATION.md) at
 On the Linux machine that you will be using as the Docker host for your SCIM bridge:
 
 1. If you haven't already done so, [install Docker Engine](https://docs.docker.com/engine/install/#server) on the Linux server. Follow the Server instructions; Docker Desktop is not needed for the Linux server.
-
 2. Follow the [post-install steps](https://docs.docker.com/engine/install/linux-postinstall/) as noted in the documentation to enable running Docker as a non-root user and ensure that Docker Engine starts when the Linux server boots.
 
 ### 👨‍💻 Prepare your desktop and initialize the Swarm
@@ -48,8 +47,16 @@ All following steps should be run on the same computer where you are already usi
     ```
 
 3. Save the `scimsession` credentials file from [the Automated User Provisioning setup](https://start.1password.com/integrations/directory/) to this working directory.
+4. Open `scim.env` in your favourite text editor. Set the value of `OP_TLS_DOMAIN` to the fully qualififed domain name of the public DNS record for your SCIM bridge created in [Get started](#get-started). For example:
 
-4. Create and use a Docker context:
+   ```dotenv
+   # ...
+   OP_TLS_DOMAIN=scim.example.com
+   
+   # ...
+   ```
+
+5. Create and use a Docker context:
 
    *Example commands:*
 
@@ -61,8 +68,7 @@ All following steps should be run on the same computer where you are already usi
    ```
 
    Copy the example command to a text editor. Replace `user` with the appropriate username for your Linux server and `scim.example.com` with the host name or IP address used for SSH access to the Linux server before running the above commands in your terminal.
-
-5. Initialize the Swarm. Run this command:
+6. Initialize the Swarm. Run this command:
 
    ```sh
    docker swarm init # --advertise-addr 192.0.2.1
@@ -74,15 +80,14 @@ All following steps should be run on the same computer where you are already usi
 
 ### Configure 1Password SCIM bridge to connect to Google Workspace
 
-If integrating 1Password with Google Workspace, additional cofiguration is required. See [Connect Google Workspace to 1Password SCIM Bridge](https://support.1password.com/scim-google-workspace/#step-1-create-a-google-service-account-key-and-api-client) for instructions to create the service account, key, and API client.
+If integrating 1Password with Google Workspace, additional configuration is required. See [Connect Google Workspace to 1Password SCIM Bridge](https://support.1password.com/scim-google-workspace/#step-1-create-a-google-service-account-key-and-api-client) for instructions to create the service account, key, and API client.
 
 > **Warning**
 >
 > If you are *not* integrating with Workspace, skip the steps in this section and [deploy your SCIM bridge](#deploy-1password-scim-bridge).
 
-1. Copy the Google Workspace service account key to the working directory.
-
-2. Copy the [Google Workspace settings template file](/beta/workspace-settings.json) from the root of this repository to the working directory:
+1. Save the Google Workspace service account key to this working directory (or rename after saving) as `workspace-credentials.json`.
+2. Copy the [Google Workspace settings template file](/beta/workspace-settings.json) in this repository to the working directory:
 
     ```sh
     cp ../workspace-settings.json ./workspace-settings.json
@@ -104,13 +109,12 @@ If integrating 1Password with Google Workspace, additional cofiguration is requi
 
 ## Deploy 1Password SCIM Bridge
 
-After the DNS record has propagated, set the fully qualified domain name for your SCIM bridge, use the template to output a canonical configuration for use with Docker Swarm, then create the stack from this configuration inline. Your SCIM bridge should automatically acquire and manage a TLS certificate from Let's Encrypt on your behalf using the domain name.
-
-*Example command:*
+Use the template to output a canonical configuration for use with Docker Swarm, then create the stack from this configuration inline. Your SCIM bridge should automatically acquire and manage a TLS certificate from Let's Encrypt on your behalf:
 
 ```sh
-OP_TLS_DOMAIN=scim.example.com docker stack config --compose-file ./compose.template.yaml |
-    docker stack deploy --compose-file - op-scim-bridge
+docker stack config \
+    --compose-file ./compose.template.yaml |
+        docker stack deploy --compose-file - op-scim-bridge
 ```
 
 Copy the example command to a text editor. Replace `scim.example.com` with the fully qualified domain name of the DNS record created in [Get started](#get-started), then run the command to deploy your SCIM bridge.
@@ -126,7 +130,7 @@ If you are integrating with Google Workspace, use `compose.gw.yaml` to create th
 *Example command:*
 
 ```sh
-OP_TLS_DOMAIN=scim.example.com docker stack config \
+docker stack config \
     --compose-file ./compose.template.yaml \
     --compose-file ./compose.gw.yaml |
         docker stack deploy --compose-file - op-scim-bridge

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -39,7 +39,7 @@ On the Linux machine that you will be using as the Docker host for your SCIM bri
 1. If you haven't already done so, [install Docker Engine](https://docs.docker.com/engine/install/#server) on the Linux server. Follow the Server instructions; Docker Desktop is not needed for the Linux server.
 2. Follow the [post-install steps](https://docs.docker.com/engine/install/linux-postinstall/) as noted in the documentation to enable running Docker as a non-root user and ensure that Docker Engine starts when the Linux server boots.
 
-### 👨‍💻 Prepare your desktop and initialize the Swarm
+### 👨‍💻 Prepare your desktop
 
 All following steps should be run on the same computer where you are already using 1Password, or another machine that can access the Linux server using SSH and has access to the `scimsession` file from the integration setup:
 
@@ -97,22 +97,25 @@ All following steps should be run on the same computer where you are already usi
    docker context use op-scim-bridge
    ```
 
-7. Initialize the Swarm. Run this command:
+### 🪄 Create a swarm
 
-   ```sh
-   docker swarm init # --advertise-addr 192.0.2.1
-   ```
+Configure Docker to [create a swarm](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/) with this Linux server as the first [manager node](https://docs.docker.com/engine/swarm/how-swarm-mode-works/nodes/#manager-nodes) for the swarm. Additional worker and manager nodes may be optionally added to a swarm for fault tolerance; this deployment example provisions a single-node swarm. Docker strictly requires an IP address to advertise to other nodes that can be used to join the swarm and for overlay networking for swarm services (whether or not additional nodes are added to the swarm).
 
-   > **Note**
-   >
-   > A single network interface **must** be used on which this swarm node can be reached by other swarm members for
-   > inter-node communication and management (even for creating a single-node swarm). If multiple network intefaces are
-   > available, Docker returns an error; uncomment the `--advertise-addr` parameter (delete `#`) and replace the example
-   > IP (`192.0.2.1`) with the IP address of the appropriate network interface.
-   >
-   > 📖 See the
-   > [`docker swarm init` command](https://docs.docker.com/engine/reference/commandline/swarm_init/#--advertise-addr)
-   > in the Docker CLI reference documentation for more details.
+Run this command to create the swarm:
+
+```sh
+docker swarm init # --advertise-addr 192.0.2.1
+```
+
+> **Note**
+>
+> If multiple IP addresses are detected, Docker returns an error; uncomment the `--advertise-addr` parameter (delete
+> `#`), replace the example IP (`192.0.2.1`) with the appropriate IP address, and run the command again. A single
+> address **must** be supplied, but connectivity using this IP address is only required by other nodes in this swarm.
+>
+> 📖 See the
+> [`docker swarm init` command](https://docs.docker.com/engine/reference/commandline/swarm_init/#--advertise-addr)
+> in the Docker CLI reference documentation for more details.
 
 ### Configure 1Password SCIM bridge to connect to Google Workspace
 

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -82,9 +82,8 @@ All following steps should be run on the same computer where you are already usi
 
    > **Note**
    >
-   > 🔑 Hint: You can store your SSH keys in 1Password and authenticate this and other SSH workflows using 1Password
-   > without writing a private key to disk using the
-   > [1Password SSH agent](https://developer.1password.com/docs/ssh/get-started).
+   > 🔑 You can store your SSH keys in 1Password and authenticate this and other SSH workflows without writing a
+   > private key to disk using the [1Password SSH agent](https://developer.1password.com/docs/ssh/get-started).
 
 6. Switch to the Docker context you just created to connect to the Docker host:
 
@@ -147,7 +146,7 @@ docker stack config \
 
 ### Connect your SCIM bridge to Google Workspace
 
-If you are integrating with Google Workspace, use the `compose.gw.yaml` file to merge the Workspace configuration and create the additional Docker secrets needed for Workspace into the canonical configuration and deploy the stack:
+If you are integrating with Google Workspace, use the `compose.gw.yaml` file to merge the Workspace configuration and create the additional Docker secrets needed for Workspace into the canonical configuration inline, and deploy the stack:
 > **Warning**
 >
 > If you are *not* integrating with Workspace, skip this section and [test your SCIM bridge](#test-your-scim-bridge).

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -99,8 +99,6 @@ All following steps should be run on the same computer where you are already usi
 
 ### 🪄 Create a swarm
 
-Configure Docker to [create a swarm](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/) with this Linux server as the first [manager node](https://docs.docker.com/engine/swarm/how-swarm-mode-works/nodes/#manager-nodes) for the swarm. Additional worker and manager nodes may be optionally added to a swarm for fault tolerance; this deployment example provisions a single-node swarm. Docker strictly requires an IP address to advertise to other nodes that can be used to join the swarm and for overlay networking for swarm services (whether or not additional nodes are added to the swarm).
-
 Run this command to create the swarm:
 
 ```sh
@@ -109,13 +107,13 @@ docker swarm init # --advertise-addr 192.0.2.1
 
 > **Note**
 >
-> If multiple IP addresses are detected, Docker returns an error; uncomment the `--advertise-addr` parameter (delete
-> `#`), replace the example IP (`192.0.2.1`) with the appropriate IP address, and run the command again. A single
-> address **must** be supplied, but connectivity using this IP address is only required by other nodes in this swarm.
+> Additional nodes may be optionally added to a swarm for fault tolerance. This command adds the Linux server as the
+> first (and only) node in the swarm, but Docker *requires* a unique IP address to advertise to other nodes (even if
+> no other nodes will be added). See [How nodes work](https://docs.docker.com/engine/swarm/how-swarm-mode-works/nodes/)
+> in the Docker documentation for more details.
 >
-> 📖 See the
-> [`docker swarm init` command](https://docs.docker.com/engine/reference/commandline/swarm_init/#--advertise-addr)
-> in the Docker CLI reference documentation for more details.
+> If multiple IP addresses are detected, Docker returns an error; uncomment the `--advertise-addr` parameter (delete
+> `#`), replace the example IP (`192.0.2.1`) with the appropriate IP address, and run the command again.
 
 ### Configure 1Password SCIM bridge to connect to Google Workspace
 

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -119,7 +119,7 @@ Additional configuration and credentials are required to integrate to integrate 
 >
 > ⏩ This section is **only** for customers who are integrating 1Password with Google Workspace for automated user
 > provisioning. If you are *not* integrating with Workspace, skip the steps in this section and
-> [deploy your SCIM bridge](#🏗️-deploy-1password-scim-bridge)
+> [deploy your SCIM bridge](#%EF%B8%8F-deploy-1password-scim-bridge)
 
 See [Connect Google Workspace to 1Password SCIM Bridge](https://support.1password.com/scim-google-workspace/#step-1-create-a-google-service-account-key-and-api-client) for instructions to create the service account, key, and API client.
 

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -163,7 +163,7 @@ docker stack config \
 Run this command to retrieve logs from the service for the SCIM bridge container:
 
 ```sh
-docker service logs op-scim-bridge_scim
+docker service logs op-scim-bridge_scim --raw
 ```
 
 Your SCIM bridge URL is based on the fully qualified domain name of the DNS record created in [Get started](#get-started), for example `https://scim.example.com/`. You can access your SCIM bridge in a web browser at this URL by signing in using your bearer token.

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -105,10 +105,13 @@ All following steps should be run on the same computer where you are already usi
 
    > **Note**
    >
-   > If Docker returns an error about multiple network interfaces, uncomment the `--advertise-addr` parameter (delete
-   > `#`) and replace the example IP (`192.0.2.1`) with the IP address of a network interface on which the server can
-   > be reached by other swarm members (even if you are currently only using a single node swarm). See the
-   > [`docker swarm init`](https://docs.docker.com/engine/reference/commandline/swarm_init/#--advertise-addr) command
+   > A single network interface **must** be used on which this swarm node can be reached by other swarm members for
+   > inter-node communication and management (even for creating a single-node swarm). If multiple network intefaces are
+   > available, Docker returns an error; uncomment the `--advertise-addr` parameter (delete `#`) and replace the example
+   > IP (`192.0.2.1`) with the IP address of the appropriate network interface.
+   >
+   > 📖 See the
+   > [`docker swarm init` command](https://docs.docker.com/engine/reference/commandline/swarm_init/#--advertise-addr)
    > in the Docker CLI reference documentation for more details.
 
 ### Configure 1Password SCIM bridge to connect to Google Workspace

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -261,7 +261,7 @@ Use your SCIM bridge URL and bearer token to [connect your identity provider to 
 
 Swarm mode in Docker Engine uses a declarative service model. Services will automatically restart tasks when updating their configuration.
 
-Use the Docker context from [Prepare your desktop and initialize the Swarm](#-prepare-your-desktop-and-initialize-the-swarm) to connect to your Docker host and manage your stack.
+Use the Docker context from [Prepare your desktop](#-prepare-your-desktop) to connect to your Docker host and manage your stack.
 
 ### ✨ Update 1Password SCIM Bridge
 
@@ -381,7 +381,7 @@ docker stack config \
 
 You may supply your own TLS certificate with CertificateManager instead of invoking Let's Encrypt. The value set for `OP_TLS_DOMAIN` must match the common name of the certificate.
 
-Save the public and private certificate key files as `cetificate.pem` and `'key.pem` (respectively) to the working directory and use the included `compose.tls.yaml` file when deploying SCIM bridge to create Docker secrets and configure SCIM bridge use this certificate when terminating TLS traffic:
+Save the public and private certificate key files as `certificate.pem` and `key.pem` (respectively) to the working directory and use the included `compose.tls.yaml` file when deploying SCIM bridge to create Docker secrets and configure SCIM bridge use this certificate when terminating TLS traffic:
 
 ```sh
 docker stack config \

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -186,6 +186,7 @@ Copy the example command to a text editor. Replace `mF_9.B5f-4.1JqM` with your b
 
 <details>
 <summary>Example JSON response</summary>
+
 > ```json
 > {
 >   "Resources": [

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -20,7 +20,7 @@ The open source Docker Engine tooling can be used to deploy 1Password SCIM Bridg
 - Docker Engine (see [Docker Engine installation overview](https://docs.docker.com/engine/install/#server)) installed on the Linux server
 - a public DNS A record pointing to the Linux server
 - SSH access to the Linux server
-- [Docker Desktop](https://docs.docker.com/desktop/install/) or Docker Engine installed on a machine with access to the Linux server and credentials from your 1Password account
+- [Docker Desktop](https://docs.docker.com/engine/install/#desktop) or Docker Engine installed on a machine with access to the Linux server and credentials from your 1Password account
 
 ## Get started
 
@@ -37,7 +37,7 @@ On the Linux machine that you will be using as the Docker host for your SCIM bri
 
 All following steps should be run on the same computer where you are already using 1Password, or another machine that can access the Linux server using SSH and has access to the `scimsession` file from the integration setup:
 
-1. If you haven't already done so, install Docker. You can use [Docker Desktop](https://docs.docker.com/desktop/install/), [install Docker Engine from binaries](https://docs.docker.com/engine/install/binaries/), or install Docker using your favourite package manager.
+1. If you haven't already done so, install Docker. You can use [Docker Desktop](https://docs.docker.com/engine/install/#desktop), [install Docker Engine from binaries](https://docs.docker.com/engine/install/binaries/), or install Docker using your favourite package manager.
 
 2. Open your preferred terminal. Clone this repository and switch to this directory:
 

--- a/beta/docker/compose.gw.yaml
+++ b/beta/docker/compose.gw.yaml
@@ -16,6 +16,8 @@ services:
       - OP_WORKSPACE_SETTINGS=/run/secrets/workspace-settings.json
 secrets:
   workspace-credentials:
+    name: workspace-credentials
     file: ./workspace-credentials.json
   workspace-settings:
+    name: workspace-settings
     file: ./workspace-settings.json

--- a/beta/docker/compose.gw.yaml
+++ b/beta/docker/compose.gw.yaml
@@ -1,13 +1,21 @@
 services:
   scim:
     secrets:
-      - workspace-credentials
-      - workspace-secrets
+      - source: workspace-credentials
+        target: workspace-credentials.json
+        uid: "999"
+        gid: "999"
+        mode: 0440
+      - source: workspace-settings
+        target: workspace-settings.json
+        uid: "999"
+        gid: "999"
+        mode: 0440
     environment:
       - OP_WORKSPACE_CREDENTIALS=/run/secrets/workspace-credentials.json
       - OP_WORKSPACE_SETTINGS=/run/secrets/workspace-settings.json
 secrets:
-  workspace-settings:
-    file: ./workspace-settings.json
   workspace-credentials:
     file: ./workspace-credentials.json
+  workspace-settings:
+    file: ./workspace-settings.json

--- a/beta/docker/compose.http.yaml
+++ b/beta/docker/compose.http.yaml
@@ -1,0 +1,4 @@
+services:
+  scim:
+    ports:
+      - 80:3002

--- a/beta/docker/compose.template.yaml
+++ b/beta/docker/compose.template.yaml
@@ -32,7 +32,6 @@ services:
     environment:
       - OP_SESSION=/run/secrets/scimsession
       - OP_REDIS_URL=redis://redis:6379
-      - OP_TLS_DOMAIN
     networks:
       - op-scim
     ports:

--- a/beta/docker/compose.template.yaml
+++ b/beta/docker/compose.template.yaml
@@ -27,7 +27,11 @@ services:
     depends_on:
       - redis
     secrets:
-      - scimsession
+      - source: scimsession
+        target: scimsession
+        uid: "999"
+        gid: "999"
+        mode: 0440
     env_file: ./scim.env
     environment:
       - OP_SESSION=/run/secrets/scimsession

--- a/beta/docker/compose.tls.yaml
+++ b/beta/docker/compose.tls.yaml
@@ -1,12 +1,12 @@
 services:
   scim:
     secrets:
-      - source: tls-cert
+      - source: op-tls-cert
         target: tls.crt
         uid: "999"
         gid: "999"
         mode: 0440
-      - source: tls-key
+      - source: op-tls-key
         target: tls.key
         uid: "999"
         gid: "999"

--- a/beta/docker/compose.tls.yaml
+++ b/beta/docker/compose.tls.yaml
@@ -1,0 +1,23 @@
+services:
+  scim:
+    secrets:
+      - source: tls-cert
+        target: tls.crt
+        uid: "999"
+        gid: "999"
+        mode: 0440
+      - source: tls-key
+        target: tls.key
+        uid: "999"
+        gid: "999"
+        mode: 0440
+    environment:
+      - OP_TLS_CERT_FILE=/run/secrets/tls.crt
+      - OP_TLS_KEY_FILE=/run/secrets/tls.key
+secrets:
+  op-tls-cert:
+    name: op-tls-cert
+    file: ./certificate.pem
+  op-tls-key:
+    name: op-tls-key
+    file: ./key.pem

--- a/beta/docker/scim.env
+++ b/beta/docker/scim.env
@@ -1,6 +1,11 @@
-# These environment variables can be can used to configure your 1Password SCIM Bridge deployment. Environment variable
+# These environment variables can be can used to customize your 1Password SCIM Bridge deployment. Environment variable
 # values set in this file will be consumed using the "env_file" key of the Compose file, and may be set or overridden by
 # the container engine during deployment.
+
+# Set OP_TLS_DOMAIN to the public DNS name that points to the public endpoint of your SCIM bridge to enable the
+# optional CertificateManager component to terminate TLS traffic on port 8443. If blank or unset, SCIM bridge can
+# receive plain-text HTTP traffic on port 3002 (or another port designated by the OP_PORT variable).
+OP_TLS_DOMAIN=
 
 # Set OP_LETSENCRYPT_EMAIL to a valid email address to provide to Let's Encrypt when using CertificateManager. If this
 # value is not set, and a certificate is not specified using the OP_TLS_KEY_FILE and OP_CERT_KEY_FILE variables, SCIM
@@ -29,39 +34,3 @@
 # behind a load balancer that requires health checks. If unset or set to 0, SCIM bridge will not respond to requests
 # sent to /ping. This value is ignored if CertificateManager is not enabled.
 # OP_PING_SERVER=1
-
-# The below environment variables are included for reference only, and will be overridden by the configuration defined
-# in the Compose specification included with this deployment example or require extra configuration. A custom Compose
-# file or override is required to use values defined in this file for these variables.
-
-# Set OP_SESSION to either the path to a valid scimsession file mounted in the container filesystem, or the Base64-
-# encoded contents of the scimsession file. If this value is not set, the SetupServer component that is exclusively
-# used by our marketplace deployments will be enabled. Valid scimsession credentials are required for all
-# custom deployments.
-# OP_SESSION=eyJ2ZXJzaW9uIjoiMiIsInZlcmlmaWVyIjp7InNhbHQiOiIzaklmUEllNTFhRzJVMDlLQjJneDRnIiwibG9jYWxIYXNoIjoiWldxU3...
-# - or -
-# OP_SESSION=/path/to/scimsession
-
-# Set OP_REDIS_URL to a valid Redis URI connection string for an available Redis server.
-# OP_REDIS_URL=redis://user:secret@localhost:6379/0
-
-# Set OP_PORT to the port number on which to receive plain-text HTTP traffic SCIM requests when CertificateManager is
-# not enabled. Ports 8080 and 8443 are reserved for the SetupServer component used exclusively by our marketplace
-# deployments and the CertificateManager component, resepectively. If not set, the default value of 3002 is used.
-# OP_PORT=65536
-
-# Set OP_TLS_DOMAIN to the public DNS name that points to the public endpoint of your SCIM bridge to enable the
-# optional CertificateManager component to terminate TLS traffic on port 8443. If blank or unset, SCIM bridge can
-# receive plain-text HTTP traffic on port 3002 (or another port designated by the OP_PORT variable).
-# OP_TLS_DOMAIN=op-scim.example.com
-
-# To use your own TLS certificate with CertificateManager, set OP_TLS_KEY_FILE to the path of a valid private TLS
-# certificate key file that is paired to the public key specified in OP_TLS_CERT_FILE, and set OP_TLS_CERT_FILE to the
-# path of a valid public TLS certificate key file that is paired to the private key specified in OP_TLS_KEY_FILE. If
-# only one of the two values is set, the CertificateManager will fail to load. If neither value is set,
-# and CertificateManager is enabled, it will request and manage a TLS certificate for SCIM bridge using Let's Encrypt.
-# OP_TLS_KEY_FILE=/path/to/key.pem
-# OP_TLS_CERT_FILE=/path/to/cert.pem
-
-# Set OP_DNS_CHALLENGE_CONFIG_FILE sets the path to a Let's Encrypt DNS-01 configuration file
-# OP_DNS_CHALLENGE_CONFIG_FILE=/path/to/dns01.example.json


### PR DESCRIPTION
This PR improves on the beta Docker Swarm deployment example (`/beta/docker`)

Rejigged setup workflow:
- move `OP_TLS_DOMAIN` declaration to `scim.env`
- remove redundant `scim.env` entries
- remove redundant example references
- added configs for advanced options

README improvements:
- typos, grammar
- clarify some steps
- add hints to helpful 1Password tooling
- add more links to Docker docs
- better explanations of some Docker concepts
- `--raw` flag in logs command for more more legible log output
- added advanced setup topics in appendix
- moar heading emoji 🎉😍