### PR TITLE
AWS CloudFormation example enhancements

### DIFF
--- a/beta/aws-ecsfargate-cfn/README.md
+++ b/beta/aws-ecsfargate-cfn/README.md
@@ -104,6 +104,7 @@ aws cloudformation deploy --template-file ./op-scim-bridge.yaml
       # WorkspaceCredentials=$(cat ./workspace-credentials.json) \
       # WorkspaceActor=admin@example.com \
       # VPCCIDR=10.0.0.0/16 \
+      # ProvisioningVolume=high \
    # --tags \
    #    Key1=Value1 \
    #    Key2=Value2 \
@@ -140,7 +141,7 @@ Edit the example above as follows before running the command from the working di
      # ...
      ```
 
-- Uncomment the appropriate lines as needed to adjust the CIDR block for the VPC and add tags as key-value pairs to apply to all supported resources in the stack.
+- Uncomment the appropriate lines as needed to adjust the CIDR block for the VPC, the scale of the deployment based on its provisoning volume, and add tags as key-value pairs to apply to all supported resources in the stack.
 - If you prefer, set the value for `--stack-name` to choose your own (for example, `--stack-name your-stack-name`). CloudFormation will use the stack name (or a truncated version where needed) as a prefix when naming the created AWS resources.
    > **Note**
    >

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -15,7 +15,7 @@ Metadata:
           - scimsession
       - Label:
           default: >-
-            Google Workspace configuration (only for customers integrating with Google Workspace)
+            Workspace configuration (only for customers integrating with Google Workspace)
         Parameters:
           - WorkspaceCredentials
           - WorkspaceActor
@@ -127,11 +127,15 @@ Resources:
       NetworkMode: awsvpc
       Cpu: 512
       Memory: 1024
+      Volumes:
+        - Name: redis-config
+        - Name: opuser-data
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: op-scim-bridge
           Image: !Sub "1password/scim:${SCIMBridgeVersion}"
+          User: "opuser:opuser"
           PortMappings:
             - ContainerPort: 3002
               HostPort: 3002
@@ -153,18 +157,28 @@ Resources:
               - Name: OP_WORKSPACE_SETTINGS
                 ValueFrom: !Ref WorkspaceSettingsSecret
               - !Ref "AWS::NoValue"
+          MountPoints:
+            - ContainerPath: /home/opuser
+              SourceVolume: opuser-data
           LogConfiguration:
             LogDriver: awslogs
             Options:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: ecs-scim
+              awslogs-stream-prefix: !Ref LogStream
         - Name: redis
           Image: "redis:latest"
-          Environment:
-            - Name: REDIS_ARGS
-              Value: '--maxmemory 256mb --maxmemory-policy volatile-lru --save ""'
+          User: "redis:redis"
+          Command:
+            - "redis-server"
+            - "/home/redis/config/redis.conf"
+          MountPoints:
+            - ContainerPath: /home/redis
+              SourceVolume: redis-config
           Essential: true
+          DependsOn:
+            - Condition: COMPLETE
+              ContainerName: init-redis
           PortMappings:
             - ContainerPort: 6379
               HostPort: 6379
@@ -178,10 +192,69 @@ Resources:
             Options:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: ecs-redis
+              awslogs-stream-prefix: !Ref LogStream
+        - Name: init-host
+          Image: bash
+          Essential: false
+          MountPoints:
+            - ContainerPath: /home/redis
+              SourceVolume: redis-config
+            - ContainerPath: /home/opuser
+              SourceVolume: opuser-data
+          Command:
+            - -c
+            - echo "Setting directory ownership..." &&
+              chown -R 999:999 /home/redis /home/opuser && echo "Directory ownership assigned!"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: !Ref LogStream
+        - Name: init-redis
+          Image: bash
+          Essential: false
+          DependsOn:
+            - Condition: COMPLETE
+              ContainerName: init-host
+          User: "999:999"
+          Command:
+            - -c
+            - echo "Creating Redis config directory..." &&
+              mkdir /home/redis/config && echo "Directory created!" &&
+              echo "Writing configuration file..." &&
+              echo $REDIS_CONFIG | base64 -d - | tee /home/redis/config/redis.conf && echo "Configuration file saved!" &&
+              echo "Setting configuration file permissions..." &&
+              chmod 0440 /home/redis/config/redis.conf && echo "File permissions set!"
+          Environment:
+            - Name: REDIS_CONFIG
+              Value:
+                Fn::Base64: |
+                  # Configure Redis as cache
+
+                  # Cache memory limit
+                  maxmemory 256mb
+
+                  # Evict only expired keys when memory limit is reached using least recently used algorithm
+                  maxmemory-policy volatile-lru
+
+                  # Disable snapshotting
+                  save ""
+          MountPoints:
+            - ContainerPath: /home/redis
+              SourceVolume: redis-config
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: !Ref LogStream
   LogGroup:
     Type: "AWS::Logs::LogGroup"
-    Properties: {}
+  LogStream:
+    Type: "AWS::Logs::LogStream"
+    Properties:
+      LogGroupName: !Ref LogGroup
   ECSService:
     Type: "AWS::ECS::Service"
     DependsOn: HTTPSListener
@@ -210,7 +283,7 @@ Resources:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
       HealthCheckIntervalSeconds: 10
-      HealthCheckPath: /app
+      HealthCheckPath: /ping
       Matcher:
         HttpCode: "200,301,302"
       HealthCheckTimeoutSeconds: 5
@@ -463,4 +536,4 @@ Outputs:
     Description: >-
       The URL for your SCIM bridge. Use this and your bearer token to connect
       your identity provider to 1Password.
-    Value: !Sub "https://${DNSRecord}/"
+    Value: !Sub "https://${DNSRecord}"

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -4,20 +4,23 @@ Description: >-
   configures a VPC, 2 public subnets, an internet gateway, a route table, an
   ALB, an ACM certificate, Route 53 DNS records, an AWS secret to store
   credentials for your SCIM bridge, security groups, and required IAM roles.
-Metadata: 
-  AWS::CloudFormation::Interface: 
+Metadata:
+  AWS::CloudFormation::Interface:
     ParameterGroups:
-      - 
-        Label: 
-          default: ""
-        Parameters: 
+      - Parameters:
           - VPCCIDR
           - Route53HostedZoneID
           - DomainName
           - SCIMBridgeVersion
           - scimsession
-    ParameterLabels: 
-      VPCCIDR: 
+      - Label:
+          default: >-
+            Google Workspace configuration (only for customers integrating with Google Workspace)
+        Parameters:
+          - WorkspaceCredentials
+          - WorkspaceActor
+    ParameterLabels:
+      VPCCIDR:
         default: "VPC CIDR"
       Route53HostedZoneID:
         default: "Route 53 hosted zone"
@@ -25,41 +28,91 @@ Metadata:
         default: "1Password SCIM Bridge domain name"
       SCIMBridgeVersion:
         default: "1Password SCIM Bridge version"
+      WorkspaceCredentials:
+        default: "Service account key"
+      WorkspaceActor:
+        default: "Actor"
 Parameters:
   VPCCIDR:
     Type: String
     Default: 10.0.0.0/16
-    Description: A CIDR block for the VPC to be created
+    Description: A CIDR block for the VPC to be created.
   Route53HostedZoneID:
-    Type: 'AWS::Route53::HostedZone::Id'
+    Type: "AWS::Route53::HostedZone::Id"
     Description: >-
-      The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB
+      The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB endpoint.
   DomainName:
     Type: String
     Default: scim.example.com
     Description: >-
-      A fully qualified domain name for your SCIM bridge; this must be in the
-      domain of the selected Route 53 hosted zone (where the record will be
-      created)
+      A fully qualified domain name for your SCIM bridge that is in the domain of the selected Route 53 hosted zone
+      where the record will be created.
   scimsession:
     Type: String
     Description: >-
-      The plain text contents of the scimsession file created during the
-      automated user provisioning setup in your 1Password account
+      The plain text contents of the scimsession file created during the automated user provisioning setup in your
+      1Password account.
+    MinLength: "1"
+    ConstraintDescription: "must not be empty"
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: 'v2.8.4'
+    Default: "v2.8.4"
     Description: >-
-      The tag of the 1Password SCIM Bridge image to pull from Docker Hub
+      The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
+  WorkspaceCredentials:
+    Type: String
+    Description: >-
+      The plain text contents of the key file associated with the service account for Google Workspace.
+    NoEcho: true
+  WorkspaceActor:
+    Type: String
+    Description: >-
+      The email address of the Google Workspace administrator that the service account is acting on behalf of.
+Rules:
+  ValidateWorkspaceConfig:
+    RuleCondition: !Not
+      - "Fn::EachMemberEquals":
+          - - !Ref WorkspaceCredentials
+            - !Ref WorkspaceActor
+          - ""
+    Assertions:
+      - Assert: !Not [!Equals [!Ref WorkspaceCredentials, ""]]
+        AssertDescription: >-
+          The service account key is required to connect to Google Workspace.
+      - Assert: !Not [!Equals [!Ref WorkspaceActor, ""]]
+        AssertDescription: >-
+          The actor email is required to connect to Google Workspace.
+Conditions:
+  UsingGoogleWorkspace: !Not
+    - !Or
+      - !Equals [!Ref WorkspaceCredentials, ""]
+      - !Equals [!Ref WorkspaceActor, ""]
 Resources:
   scimsessionSecret:
-    Type: 'AWS::SecretsManager::Secret'
+    Type: "AWS::SecretsManager::Secret"
     Properties:
       SecretString: !Base64
         Ref: scimsession
+  WorkspaceCredentialsSecret:
+    Type: "AWS::SecretsManager::Secret"
+    Condition: UsingGoogleWorkspace
+    Properties:
+      SecretString: !Base64
+        Ref: WorkspaceCredentials
+  WorkspaceSettingsSecret:
+    Type: "AWS::SecretsManager::Secret"
+    Condition: UsingGoogleWorkspace
+    Properties:
+      SecretString:
+        Fn::Base64: !Sub |
+          {
+            "actor":"${WorkspaceActor}",
+            "bridgeAddress":"https://${DNSRecord}"
+          }
+
   ECSCluster:
-    Type: 'AWS::ECS::Cluster'
+    Type: "AWS::ECS::Cluster"
     Properties:
       CapacityProviders:
         - FARGATE
@@ -67,7 +120,7 @@ Resources:
         - CapacityProvider: FARGATE
           Weight: 1
   ECSTaskDefinition:
-    Type: 'AWS::ECS::TaskDefinition'
+    Type: "AWS::ECS::TaskDefinition"
     Properties:
       RequiresCompatibilities:
         - FARGATE
@@ -78,7 +131,7 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: op-scim-bridge
-          Image: !Sub '1password/scim:${SCIMBridgeVersion}'
+          Image: !Sub "1password/scim:${SCIMBridgeVersion}"
           PortMappings:
             - ContainerPort: 3002
               HostPort: 3002
@@ -87,23 +140,30 @@ Resources:
           DependsOn:
             - ContainerName: redis
               Condition: HEALTHY
-          Environment:
-            - Name: OP_REDIS_URL
-              Value: 'redis://localhost:6379'
           Secrets:
             - Name: OP_SESSION
               ValueFrom: !Ref scimsessionSecret
+            - !If
+              - UsingGoogleWorkspace
+              - Name: OP_WORKSPACE_CREDENTIALS
+                ValueFrom: !Ref WorkspaceCredentialsSecret
+              - !Ref "AWS::NoValue"
+            - !If
+              - UsingGoogleWorkspace
+              - Name: OP_WORKSPACE_SETTINGS
+                ValueFrom: !Ref WorkspaceSettingsSecret
+              - !Ref "AWS::NoValue"
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-region: !Ref 'AWS::Region'
+              awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: ecs-scim
         - Name: redis
-          Image: 'redis:latest'
+          Image: "redis:latest"
           Environment:
             - Name: REDIS_ARGS
-              Value: '--maxmemory 256mb --maxmemory-policy volatile-lru'
+              Value: '--maxmemory 256mb --maxmemory-policy volatile-lru --save ""'
           Essential: true
           PortMappings:
             - ContainerPort: 6379
@@ -111,19 +171,19 @@ Resources:
               Protocol: tcp
           HealthCheck:
             Command:
-                - "CMD-SHELL"
-                - "redis-cli ping | grep PONG"
+              - "CMD-SHELL"
+              - "redis-cli ping | grep PONG"
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-region: !Ref 'AWS::Region'
+              awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: ecs-redis
   LogGroup:
-    Type: 'AWS::Logs::LogGroup'
+    Type: "AWS::Logs::LogGroup"
     Properties: {}
   ECSService:
-    Type: 'AWS::ECS::Service'
+    Type: "AWS::ECS::Service"
     DependsOn: HTTPSListener
     Properties:
       Cluster: !Ref ECSCluster
@@ -147,12 +207,12 @@ Resources:
           ContainerPort: 3002
           TargetGroupArn: !Ref TargetGroup
   TargetGroup:
-    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /app
       Matcher:
-        HttpCode: '200,301,302'
+        HttpCode: "200,301,302"
       HealthCheckTimeoutSeconds: 5
       UnhealthyThresholdCount: 2
       HealthyThresholdCount: 2
@@ -165,7 +225,7 @@ Resources:
       VpcId: !Ref VPC
   LoadBalancer:
     DependsOn: GatewayAttachment
-    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
     Properties:
       Scheme: internet-facing
       Subnets:
@@ -174,7 +234,7 @@ Resources:
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
   LoadBalancerSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
         Allow public HTTPS ingress to the load balancer from the identity
@@ -191,7 +251,7 @@ Resources:
           ToPort: 3002
           CidrIp: !GetAtt VPC.CidrBlock
   ServiceSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
         Restrict ingress to ECS Service from load balancer, allow egress to
@@ -208,7 +268,7 @@ Resources:
           ToPort: 443
           CidrIp: 0.0.0.0/0
   HTTPSListener:
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:
       DefaultActions:
         - Type: forward
@@ -219,17 +279,17 @@ Resources:
       Certificates:
         - CertificateArn: !Ref TLSCertificate
   ExecutionRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: ''
+          - Sid: ""
             Effect: Allow
             Principal:
               Service:
                 - ecs-tasks.amazonaws.com
-            Action: 'sts:AssumeRole'
+            Action: "sts:AssumeRole"
       Policies:
         - PolicyName: secrets_manager_policy
           PolicyDocument:
@@ -237,32 +297,40 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'secretsmanager:GetSecretValue'
+                  - "secretsmanager:GetSecretValue"
                 Resource:
                   - !Ref scimsessionSecret
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceCredentialsSecret
+                    - !Ref "AWS::NoValue"
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceSettingsSecret
+                    - !Ref "AWS::NoValue"
         - PolicyName: inlined_managed_policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
-                  - 'ec2:AuthorizeSecurityGroupIngress'
-                  - 'ec2:Describe*'
-                  - 'ecr:BatchCheckLayerAvailability'
-                  - 'ecr:BatchGetImage'
-                  - 'ecr:GetAuthorizationToken'
-                  - 'ecr:GetDownloadUrlForLayer'
-                  - 'elasticloadbalancing:DeregisterInstancesFromLoadBalancer'
-                  - 'elasticloadbalancing:DeregisterTargets'
-                  - 'elasticloadbalancing:Describe*'
-                  - 'elasticloadbalancing:RegisterInstancesWithLoadBalancer'
-                  - 'elasticloadbalancing:RegisterTargets'
-                  - 'logs:CreateLogGroup'
-                  - 'logs:CreateLogStream'
-                  - 'logs:PutLogEvents'
-                Resource: '*'
+                  - "ec2:AuthorizeSecurityGroupIngress"
+                  - "ec2:Describe*"
+                  - "ecr:BatchCheckLayerAvailability"
+                  - "ecr:BatchGetImage"
+                  - "ecr:GetAuthorizationToken"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+                  - "elasticloadbalancing:DeregisterTargets"
+                  - "elasticloadbalancing:Describe*"
+                  - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                  - "elasticloadbalancing:RegisterTargets"
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: "*"
   DNSRecord:
-    Type: 'AWS::Route53::RecordSet'
+    Type: "AWS::Route53::RecordSet"
     Properties:
       HostedZoneId: !Ref Route53HostedZoneID
       Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
@@ -272,7 +340,7 @@ Resources:
         DNSName: !GetAtt LoadBalancer.DNSName
         HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
   TLSCertificate:
-    Type: 'AWS::CertificateManager::Certificate'
+    Type: "AWS::CertificateManager::Certificate"
     Properties:
       DomainName: !Ref DNSRecord
       ValidationMethod: DNS
@@ -280,7 +348,7 @@ Resources:
         - DomainName: !Ref DNSRecord
           HostedZoneId: !Ref Route53HostedZoneID
   TaskRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -290,7 +358,7 @@ Resources:
               Service:
                 - ecs-tasks.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - "sts:AssumeRole"
       Path: /
       Policies:
         - PolicyName: cloudwatch_logging
@@ -299,94 +367,94 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'logs:CreateLogGroup'
-                  - 'logs:CreateLogStream'
-                  - 'logs:PutLogEvents'
-                Resource: '*'
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: "*"
         - PolicyName: vpc_access
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
-                  - 'ec2:CreateNetworkInterface'
-                  - 'ec2:DescribeNetworkInterfaces'
-                  - 'ec2:DeleteNetworkInterface'
-                Resource: '*'
+                  - "ec2:CreateNetworkInterface"
+                  - "ec2:DescribeNetworkInterfaces"
+                  - "ec2:DeleteNetworkInterface"
+                Resource: "*"
         - PolicyName: task_execution_role_policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
-                  - 'ecr:GetAuthorizationToken'
-                  - 'ecr:BatchCheckLayerAvailability'
-                  - 'ecr:GetDownloadUrlForLayer'
-                  - 'ecr:BatchGetImage'
-                Resource: '*'
+                  - "ecr:GetAuthorizationToken"
+                  - "ecr:BatchCheckLayerAvailability"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "ecr:BatchGetImage"
+                Resource: "*"
   VPC:
-    Type: 'AWS::EC2::VPC'
+    Type: "AWS::EC2::VPC"
     Properties:
       CidrBlock: !Ref VPCCIDR
       EnableDnsHostnames: true
       EnableDnsSupport: true
   PublicSubnet1:
-    Type: 'AWS::EC2::Subnet'
+    Type: "AWS::EC2::Subnet"
     Properties:
       AvailabilityZone:
-        'Fn::Select':
+        "Fn::Select":
           - 0
-          - 'Fn::GetAZs':
-              Ref: 'AWS::Region'
+          - "Fn::GetAZs":
+              Ref: "AWS::Region"
       VpcId: !Ref VPC
       CidrBlock:
-        'Fn::Select':
+        "Fn::Select":
           - 0
-          - 'Fn::Cidr':
+          - "Fn::Cidr":
               - !GetAtt VPC.CidrBlock
               - 16
               - 12
   PublicSubnet2:
-    Type: 'AWS::EC2::Subnet'
+    Type: "AWS::EC2::Subnet"
     Properties:
       AvailabilityZone:
-        'Fn::Select':
+        "Fn::Select":
           - 1
-          - 'Fn::GetAZs':
-              Ref: 'AWS::Region'
+          - "Fn::GetAZs":
+              Ref: "AWS::Region"
       VpcId: !Ref VPC
       CidrBlock:
-        'Fn::Select':
+        "Fn::Select":
           - 1
-          - 'Fn::Cidr':
+          - "Fn::Cidr":
               - !GetAtt VPC.CidrBlock
               - 16
               - 12
   InternetGateway:
-    Type: 'AWS::EC2::InternetGateway'
+    Type: "AWS::EC2::InternetGateway"
   GatewayAttachment:
-    Type: 'AWS::EC2::VPCGatewayAttachment'
+    Type: "AWS::EC2::VPCGatewayAttachment"
     Properties:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
   RouteTable:
-    Type: 'AWS::EC2::RouteTable'
+    Type: "AWS::EC2::RouteTable"
     Properties:
       VpcId: !Ref VPC
   Route:
-    Type: 'AWS::EC2::Route'
+    Type: "AWS::EC2::Route"
     DependsOn: GatewayAttachment
     Properties:
       RouteTableId: !Ref RouteTable
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
   PublicSubnet1RouteTableAssociation:
-    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
     Properties:
       SubnetId: !Ref PublicSubnet1
       RouteTableId: !Ref RouteTable
   PublicSubnet2RouteTableAssociation:
-    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
     Properties:
       SubnetId: !Ref PublicSubnet2
       RouteTableId: !Ref RouteTable
@@ -395,4 +463,4 @@ Outputs:
     Description: >-
       The URL for your SCIM bridge. Use this and your bearer token to connect
       your identity provider to 1Password.
-    Value: !Sub 'https://${DNSRecord}/'
+    Value: !Sub "https://${DNSRecord}/"

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -10,6 +10,7 @@ Metadata:
       - Parameters:
           - VPCCIDR
           - Route53HostedZoneID
+          - ProvisioningVolume
           - DomainName
           - SCIMBridgeVersion
           - scimsession
@@ -24,6 +25,8 @@ Metadata:
         default: "VPC CIDR"
       Route53HostedZoneID:
         default: "Route 53 hosted zone"
+      ProvisioningVolume:
+        default: "Provisioning volume"
       DomainName:
         default: "1Password SCIM Bridge domain name"
       SCIMBridgeVersion:
@@ -41,6 +44,17 @@ Parameters:
     Type: "AWS::Route53::HostedZone::Id"
     Description: >-
       The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB endpoint.
+  ProvisioningVolume:
+    Type: String
+    Description: >-
+      The expected volume of provisioning activity. Use base for provisioning less than 1,000 users, high for up to
+      5,000 users, or very-high for more than 5,000 users.
+    Default: base
+    AllowedValues:
+      - base
+      - high
+      - very-high
+    ConstraintDescription: must be base, high, or very-high
   DomainName:
     Type: String
     Default: scim.example.com
@@ -83,6 +97,33 @@ Rules:
       - Assert: !Not [!Equals [!Ref WorkspaceActor, ""]]
         AssertDescription: >-
           The actor email is required to connect to Google Workspace.
+Mappings:
+  CpuScale:
+    base:
+      SCIMBridge: 128
+      Redis: 128
+      Task: 256
+    high:
+      SCIMBridge: 256
+      Redis: 256
+      Task: 512
+    very-high:
+      SCIMBridge: 1024
+      Redis: 1024
+      Task: 2048
+  MemoryScale:
+    base:
+      SCIMBridge: 512
+      Redis: 512
+      Task: 1024
+    high:
+      SCIMBridge: 1024
+      Redis: 1024
+      Task: 2048
+    very-high:
+      SCIMBridge: 2048
+      Redis: 2048
+      Task: 4096
 Conditions:
   UsingGoogleWorkspace: !Not
     - !Or
@@ -125,8 +166,14 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       NetworkMode: awsvpc
-      Cpu: 512
-      Memory: 1024
+      Cpu: !FindInMap
+        - CpuScale
+        - !Ref ProvisioningVolume
+        - Task
+      Memory: !FindInMap
+        - MemoryScale
+        - !Ref ProvisioningVolume
+        - Task
       Volumes:
         - Name: redis-config
         - Name: opuser-data
@@ -134,6 +181,14 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: op-scim-bridge
+          Cpu: !FindInMap
+            - CpuScale
+            - !Ref ProvisioningVolume
+            - SCIMBridge
+          Memory: !FindInMap
+            - MemoryScale
+            - !Ref ProvisioningVolume
+            - SCIMBridge
           Image: !Sub "1password/scim:${SCIMBridgeVersion}"
           User: "opuser:opuser"
           PortMappings:
@@ -167,6 +222,14 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: !Ref LogStream
         - Name: redis
+          Cpu: !FindInMap
+            - CpuScale
+            - !Ref ProvisioningVolume
+            - Redis
+          Memory: !FindInMap
+            - MemoryScale
+            - !Ref ProvisioningVolume
+            - Redis
           Image: "redis:latest"
           User: "redis:redis"
           Command:


### PR DESCRIPTION
This PR adds some improvements to our example CloudFormation template, mainly to enable customers using Google Workspace to deploy a stack with the necessary configuration to connect to Workspace:

- introduce Workspace config:
    - parameters, condition and rule for Workspace config
    - conditional secrets for creds & settings file
    - relevant conditional policy to access Workspace secrets
- introduce vertical scaling presets based on expected provisioning volume
- removed redundant `OP_REDIS_URL` environment variable
- set `/ping` as target group health check endpoint to cut down on redundant log entries from the load balancer
- run containers in context of non-root users
- mount host volumes for Redis and SCIM bridge containers
- introduce LogStream resource to use for log-prefix
- introduce ephemeral initialization containers to:
  - change ownership of container volume mounts
  - create Redis configuration file
  - log these actions
- load Redis config from file on boot
- disable Redis persistence (turn off snapshots)
- clarified some descriptive text
- add appropriate instructions to `./README.md` for connecting to Google Workspace
- simplify and clarify some steps
- white space & formatting

The template can be used for new SCIM bridges connecting to Google Workspace for the first time or to update an existing stack with or without Google Workspace configuration that is deployed using this template or the current template on `master`.