### PR TITLE
Bump to v2.8.4

### DIFF
--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "op_scim_bridge",
-    "image": "1password/scim:v2.8.3",
+    "image": "1password/scim:v2.8.4",
     "cpu": 128,
     "memory": 512,
     "essential": true,

--- a/beta/aws-ecsfargate-cfn/README.md
+++ b/beta/aws-ecsfargate-cfn/README.md
@@ -215,12 +215,12 @@ aws cloudformation deploy \
     --template-file ./op-scim-bridge.yaml \
     --stack-name op-scim-bridge \
     --capabilities CAPABILITY_IAM \
-    --parameter-overrides SCIMBridgeVersion=v2.8.3
+    --parameter-overrides SCIMBridgeVersion=v2.8.4
 ```
 
 > **Note**
 >
 > Our [1Password SCIM Bridge release notes page](https://app-updates.agilebits.com/product_history/SCIM) does not include `v` in each release version, but this character must be included in the value of the `SCIMBridgeVersion` parameter to match the corresponding [image tag in Docker Hub](https://hub.docker.com/r/1password/scim/tags):
 >
-> - ✅ `v2.8.3`
-> - ❌ `2.8.3`
+> - ✅ `v2.8.4`
+> - ❌ `2.8.4`

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -49,7 +49,7 @@ Parameters:
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: 'v2.8.3'
+    Default: 'v2.8.4'
     Description: >-
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub
 Resources:

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -114,7 +114,7 @@ Both methods need the Container App Extension added to the AZ tool of choice, by
     ```bash
     az containerapp create -n $ContainerAppName -g $ResourceGroup \
         --container-name op-scim-bridge \
-        --image docker.io/1password/scim:v2.8.3 \
+        --image docker.io/1password/scim:v2.8.4 \
         --environment $ContainerAppEnvironment \
         --ingress external --target-port 3002 \
         --cpu 0.25 --memory 0.5Gi \
@@ -126,7 +126,7 @@ Both methods need the Container App Extension added to the AZ tool of choice, by
     ```pwsh
     az containerapp create -n $ContainerAppName -g $ResourceGroup `
     --container-name op-scim-bridge `
-    --image docker.io/1password/scim:v2.8.3 `
+    --image docker.io/1password/scim:v2.8.4 `
     --environment $ContainerAppEnvironment `
     --ingress external --target-port 3002 `
     --cpu 0.25 --memory 0.5Gi `
@@ -220,7 +220,7 @@ The `scimsession` credentials will be saved as a secret variable in Container Ap
     1. Uncheck **Use quickstart image**.
     2. Change the name of the container to *op-scim-bridge*.
     3. Select **Docker Hub** for the image source.
-    4. Enter `1password/scim:v2.8.3` for the **Image and Tag**.
+    4. Enter `1password/scim:v2.8.4` for the **Image and Tag**.
     5. Leave the CPU and Memory as 0.25 CPU cores, 0.5 Gi memory.
     6. Add the following **Environment variables**:
         1. `OP_SESSION` currently with of `""` for now.
@@ -487,8 +487,8 @@ Logs for a container app can be viewed from the **Log Stream**, there is a separ
 The latest version of 1Password SCIM Bridge is posted on our [Release Notes](https://app-updates.agilebits.com/product_history/SCIM) website, where you can find details about the latest changes. 
 
 1. Start the Azure Cloud Shell from the navigation bar of your [Azure Portal](https://portal.azure.com) or directly open the [Azure Shell](https://shell.azure.com).
-2. Run the following command, replacing `$ContainerAppName` and `$ResourceGroup` with the names from your deployment. Also ensure to change the version number 2.8.3 to match the latest version from our [SCIM Bridge Release Notes page](https://app-updates.agilebits.com/product_history/SCIM).
-```az containerapp update -n $ContainerAppName -g $ResourceGroup --container-name op-scim-bridge --image docker.io/1password/scim:v2.8.3```
+2. Run the following command, replacing `$ContainerAppName` and `$ResourceGroup` with the names from your deployment. Also ensure to change the version number 2.8.4 to match the latest version from our [SCIM Bridge Release Notes page](https://app-updates.agilebits.com/product_history/SCIM).
+```az containerapp update -n $ContainerAppName -g $ResourceGroup --container-name op-scim-bridge --image docker.io/1password/scim:v2.8.4```
 3. Log into your SCIM bridge URL with your bearer token to validate in the top left hand side that you are running the version of the SCIM Bridge. (logging in with the bearer token will also update your Automated User Provisioning page with the latest access time and with the current version).
 
 #### Update using the Azure Portal
@@ -496,7 +496,7 @@ The latest version of 1Password SCIM Bridge is posted on our [Release Notes](htt
 1. Within Container App from the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), Select **Containers** from the left hand side.
 2. Select **Edit and deploy** along the top.
 3. Put a check in the box next to your **op-scim-bridge** container and select **Edit**.
-4. Change the version number **2.8.3** in the **Image and Tag** field, **1password/scim:v2.8.3** to match the latest version from our [SCIM Bridge Release Notes page](https://app-updates.agilebits.com/product_history/SCIM).
+4. Change the version number **2.8.4** in the **Image and Tag** field, **1password/scim:v2.8.4** to match the latest version from our [SCIM Bridge Release Notes page](https://app-updates.agilebits.com/product_history/SCIM).
 5. Select **Save**.
 6. Select **Create** to deploy a new revision using the updating image.
 7. Log into your SCIM bridge URL with your bearer token to validate in the top left hand side that you are running the version of the SCIM Bridge. (logging in with the bearer token will also update your Automated User Provisioning page with the latest access time and with the current version).

--- a/beta/do-app-platform-op-cli/op-scim-bridge.yaml
+++ b/beta/do-app-platform-op-cli/op-scim-bridge.yaml
@@ -32,7 +32,7 @@ services:
     registry: 1password
     registry_type: DOCKER_HUB
     repository: scim
-    tag: v2.8.3
+    tag: v2.8.4
   instance_count: 1
   instance_size_slug: basic-xxs
   name: op-scim-bridge

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -264,7 +264,7 @@ Update the `op-scim-bridge_scim` service with the new image tag from the [`1pass
 
 ```sh
 docker service update op-scim-bridge_scim \
-    --image 1password/scim:v2.8.3
+    --image 1password/scim:v2.8.4
 ```
 
 > **Note**

--- a/beta/docker/compose.template.yaml
+++ b/beta/docker/compose.template.yaml
@@ -23,7 +23,7 @@ services:
       timeout: 3s
       retries: 5
   scim:
-    image: 1password/scim:v2.8.3
+    image: 1password/scim:v2.8.4
     depends_on:
       - redis
     secrets:

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   scim:
-    image: 1password/scim:v2.8.3
+    image: 1password/scim:v2.8.4
     ports:
       - "3002:3002"
       - "80:8080"

--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   scim:
-    image: 1password/scim:v2.8.3
+    image: 1password/scim:v2.8.4
     deploy:
       replicas: 1
       restart_policy:

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -122,7 +122,7 @@ To finish setting up automated user provisioning, [connect your identity provide
 To update SCIM bridge, connect to your Kubernetes cluster and run the following command, replacing v2.8.0 with the latest version:
 
 ```bash
-kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.8.3
+kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.8.4
 ```
 
 The update should take 2-3 minutes for Kubernetes to complete.

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: op-scim-bridge
-          image: 1password/scim:v2.8.3
+          image: 1password/scim:v2.8.4
           ports:
             # HTTPS port (external TCP traffic should be forwarded to this port by default)
             - name: https


### PR DESCRIPTION
https://app-updates.agilebits.com/product_history/SCIM#v208041

Changelog:
```
This is a patch release primarily to provide clear instructions when provisioning users with an invalid domain. For more information on allowed domains, visit https://support.1password.com/scim-update-allowed-domains.

[FIXED]
* A clear error message is presented when provisioning or updating users with a domain not in the Allowed domains list. {3755}

[SECURITY]
* Update base distroless image to latest version. {3774}
```