### PR TITLE
Fixed curl endpoint in step 5

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -108,7 +108,7 @@ You can test your instance by requesting `https://[your-domain]/scim/Users`, wit
 For example, to do this with `curl`:
 
 ```bash
-curl --header "Authorization: Bearer TOKEN_GOES_HERE" https://scim.example.com/Users
+curl --header "Authorization: Bearer TOKEN_GOES_HERE" https://scim.example.com/scim/Users
 ```
 
 ## Step 6: Connect your identity provider


### PR DESCRIPTION
The curl example to test the SCIM bridge users endpoint was missing the `/scim/` portion which would result in the command not working. 