### PR TITLE
Bump to v2.8.4

### DIFF
--- a/beta/kustomize/base/op-scim-deployment.yaml
+++ b/beta/kustomize/base/op-scim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: op-scim-bridge
-          image: 1password/scim:v2.8.3
+          image: 1password/scim:v2.8.4
           ports:
             # HTTPS port (external TCP traffic should be forwarded to this port by default)
             - name: https


### PR DESCRIPTION
Bumps the recently added Kustomize deployment example to the latest SCIM bridge release tag.