### PR TITLE
Update AWS CloudFormation example code & yaml file

### DIFF
--- a/beta/aws-ecsfargate-cfn/README.md
+++ b/beta/aws-ecsfargate-cfn/README.md
@@ -95,7 +95,7 @@ You can alternatively deploy 1Password SCIM Bridge with a single AWS CLI command
 *Example command:*
 
 ```sh
-aws cloudformation deploy --template-file ./op-scim-bridge.yaml
+aws cloudformation deploy --template-file ./op-scim-bridge.yaml \
    --capabilities CAPABILITY_IAM \
    --parameter-overrides \
       Route53HostedZoneID=Z2ABCDEF123456 \

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -76,11 +76,13 @@ Parameters:
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
   WorkspaceCredentials:
     Type: String
+    Default: ""
     Description: >-
       The plain text contents of the key file associated with the service account for Google Workspace.
     NoEcho: true
   WorkspaceActor:
     Type: String
+    Default: ""
     Description: >-
       The email address of the Google Workspace administrator that the service account is acting on behalf of.
 Rules:


### PR DESCRIPTION
2 updates for the AWS CloudFormation SCIM bridge example

- fix minor error on example code
- add default value for WorkspaceActor & WorkspaceCredentials (it previously gave an error when these 2 parameters were not put in)

Contains same changes from #264 due to non-signed commits in #264.