### PR TITLE
Revise resource specifications and recommendations

### DIFF
--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -106,12 +106,12 @@ Mappings:
       Redis: 128
       Task: 256
     high:
-      SCIMBridge: 256
-      Redis: 256
-      Task: 512
+      SCIMBridge: 512
+      Redis: 128
+      Task: 1024
     very-high:
       SCIMBridge: 1024
-      Redis: 1024
+      Redis: 128
       Task: 2048
   MemoryScale:
     base:
@@ -120,11 +120,11 @@ Mappings:
       Task: 1024
     high:
       SCIMBridge: 1024
-      Redis: 1024
+      Redis: 512
       Task: 2048
     very-high:
-      SCIMBridge: 2048
-      Redis: 2048
+      SCIMBridge: 1024
+      Redis: 512
       Task: 4096
 Conditions:
   UsingGoogleWorkspace: !Not

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -274,55 +274,42 @@ The `scimsession` credentials will be saved as a secret variable in Container Ap
 
 ### Resource recommendations
 
-The default resource recommendations for the SCIM bridge and Redis deployments are acceptable in most scenarios, but they may fall short in high-volume deployments where a large number of users and/or groups are being managed. We strongly recommend increasing the resources for both the SCIM bridge and Redis deployments.
+The 1Password SCIM Bridge Pod should be vertically scaled when provisioning a large number of users or groups. Our default resource specifications and recommended configurations for provisioning at scale are listed in the below table:
 
-| Expected Provisioned Users |  Resources |
-| ------- | ------- |
-| 1-1000  |  Default  |
-| 1000-5000  |  High Volume Deployment  |
-| 5000+  |  Very High Volume Deployment  |
+| Volume    | Number of users | CPU   | memory |
+| --------- | --------------- | ----- | ------ |
+| Default   | <1,000          | 0.25  | 0.5Gi  |
+| High      | 1,000–5,000     | 0.5   | 1.0Gi  |
+| Very high | >5,000          | 1.0   | 1.0Gi  |
 
-Our current default resource requirements are:
+If provisioning more than 1,000 users, the resources assigned to the SCIM bridge container should be updated as recommended in the above table. The resources specified for the Redis container do not need to be adjusted.
 
-<details>
-  <summary>Default</summary>
+#### Default
 
-  ```
-    cpu: 0.25
-    memory: 0.5Gi
-  ```
-</details>
+To revert to the default specification that is suitable for provisioning up to 1,000 users:
 
-These values can be scaled down again to the default values after the initial large provisioning event.
+```sh
+az containerapp update -n $ContainerAppName -g $ResourceGroup --container-name op-scim-bridge \
+  --cpu 0.25 --memory 0.5Gi
+```
 
-<details>
-  <summary>High Volume Deployment</summary>
+#### High volume deployment
 
-While you can continue to utilize Azure Container Apps to run your SCIM bridge for an high volume deployment, we have not run this type of workload through a Azure Container Apps SCIM bridge to test the performance in an Azure Container app environment. 
+For provisioning up to 5,000 users:
 
-  ```
-    cpu: 0.5
-    memory: 1.0Gi
-  ```
-  Run the following commands, replacing `$ContainerAppName` and `$ResourceGroup` with the names from your deployment to increase the resources:
+```sh
+az containerapp update -n $ContainerAppName -g $ResourceGroup --container-name op-scim-bridge \
+  --cpu 0.5 --memory 1.0Gi
+```
 
-  ```bash
-    az containerapp update -n $ContainerAppName -g $ResourceGroup --container-name op-scim-bridge --cpu 0.5 --memory 1.0Gi
-  ```
+#### Very high volume
 
-  ```bash
-    az containerapp update -n $ContainerAppName -g $ResourceGroup --container-name op-scim-redis --cpu 0.5 --memory 1.0Gi
-  ```
+For provisioning more than 5,000 users:
 
-</details>
-
-<details>
-  <summary>Very High Volume Deployment</summary>
-
-  While you can continue to utilize Azure Container Apps to run your SCIM bridge for a very high volume deployment, we have not run this type of workload through a Azure Container Apps SCIM bridge, it is recommended to switch to an [AKS deployment](/kubernetes/README.md) using the Very High Volume deployment specs for that cluster. 
-</details>
-
-<hr>
+```sh
+az containerapp update -n $ContainerAppName -g $ResourceGroup --container-name op-scim-bridge \
+  --cpu 1.0 --memory 1.0Gi
+```
 
 ### If Google Workspace is your identity provider
 <details>

--- a/beta/docker/compose.template.yaml
+++ b/beta/docker/compose.template.yaml
@@ -11,9 +11,8 @@ services:
       resources:
         reservations:
           cpus: "0.125"
-          memory: 256M
+          memory: 512M
         limits:
-          cpus: "0.25"
           memory: 512M
       restart_policy:
         condition: any
@@ -44,9 +43,8 @@ services:
       resources:
         reservations:
           cpus: "0.125"
-          memory: 256M
+          memory: 512M
         limits:
-          cpus: "0.25"
           memory: 512M
       restart_policy:
         condition: any

--- a/beta/docker/redis.conf
+++ b/beta/docker/redis.conf
@@ -1,4 +1,10 @@
-# Configure Redis to use a specified amount of memory for the data set
+# Configure Redis as cache
+
+# Cache memory limit
 maxmemory 256mb
-# Set the eviction policy used when the maximum memory is reached
+
+# Evict only expired keys when memory limit is reached using least recently used algorithm
 maxmemory-policy volatile-lru
+
+# Disable snapshotting
+save ""

--- a/beta/kustomize/base/op-scim-deployment.yaml
+++ b/beta/kustomize/base/op-scim-deployment.yaml
@@ -29,9 +29,8 @@ spec:
           resources:
             requests:
               cpu: 125m
-              memory: 256M
+              memory: 512M
             limits:
-              cpu: 250m
               memory: 512M
           envFrom:
             - configMapRef:

--- a/beta/kustomize/base/redis-deployment.yaml
+++ b/beta/kustomize/base/redis-deployment.yaml
@@ -21,9 +21,8 @@ spec:
           resources:
             requests:
               cpu: 125m
-              memory: 256M
+              memory: 512M
             limits:
-              cpu: 250m
               memory: 512M
           envFrom:
             - configMapRef:

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -394,7 +394,7 @@ No other endpoints (such as `/scim`) are exposed through this port.
 
 ## Troubleshooting
 
-When updating cluster resources in place, Kubernetes will create a new revision alongside an existing workload before replacing the existing revision. If there are not enough available resources in the cluster on which to schedule both revisions, the update can hang until they become available. This can happening when vertically scaling a Deployment or updating to a new SCIM bridge image version.
+When cluster resources are updated in place, Kubernetes will create a new revision alongside an existing workload before replacing the existing revision. If there are not enough available resources in the cluster to schedule both revisions, the update can hang until they become available. This can happen when vertically scaling a Deployment or updating to a new SCIM bridge image version.
 
 If there are enough resources in the cluster available to schedule the new Pod revision, you can restart the Deployment to evict the existing Pod, free up the resources, and allow the new Pod to start:
 


### PR DESCRIPTION
Our engineering team responsible for developing our SCIM bridge container image has spent the last several months investigating and refining how SCIM bridge performs at scale. We now have updated guidelines for recommended resources that should be allocated to the SCIM bridge container when provisioning large numbers of users and groups to 1Password.

This PR revises our deployment examples to:

- ensure that the default resource allocations for the SCIM bridge and Redis containers on each respective platform align with our base recommendations
- include guidelines for vertically scaling at higher volumes of provisioning activity
- remove any references to scaling the Redis container and recommend always using the default resource specification