### PR TITLE
Include non-Route 53 DNS configuration option in AWS CloudFormation template

### DIFF
--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -222,7 +222,7 @@ Resources:
             Options:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
+              awslogs-stream-prefix: !Ref "AWS::StackName"
         - Name: redis
           Cpu: !FindInMap
             - CpuScale
@@ -257,7 +257,7 @@ Resources:
             Options:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
+              awslogs-stream-prefix: !Ref "AWS::StackName"
         - Name: init-host
           Image: bash
           Essential: false
@@ -275,7 +275,7 @@ Resources:
             Options:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
+              awslogs-stream-prefix: !Ref "AWS::StackName"
         - Name: init-redis
           Image: bash
           Essential: false
@@ -313,13 +313,9 @@ Resources:
             Options:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
+              awslogs-stream-prefix: !Ref "AWS::StackName"
   LogGroup:
     Type: "AWS::Logs::LogGroup"
-  LogStream:
-    Type: "AWS::Logs::LogStream"
-    Properties:
-      LogGroupName: !Ref LogGroup
   ECSService:
     Type: "AWS::ECS::Service"
     DependsOn: HTTPSListener

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -1,15 +1,15 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  Deploys 1Password SCIM Bridge using Amazon ECS and AWS Fargate. Provisions and
-  configures a VPC, 2 public subnets, an internet gateway, a route table, an
-  ALB, an ACM certificate, Route 53 DNS records, an AWS secret to store
-  credentials for your SCIM bridge, security groups, and required IAM roles.
+  Deploys 1Password SCIM Bridge using Amazon ECS and AWS Fargate. Provisions and configures a VPC, 2 public subnets, an
+  internet gateway, a route table, an ALB, an ACM certificate, AWS secrets to store credentials for your SCIM bridge,
+  security groups, and required IAM roles. Optionally creates DNS records in Route 53 for the load balancer and ACM
+  domain validation, or provides values to create them separately in your DNS provider of choice.
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Parameters:
           - VPCCIDR
-          # - Route53HostedZoneID
+          - Route53HostedZoneID
           - ProvisioningVolume
           - DomainName
           - SCIMBridgeVersion
@@ -23,8 +23,8 @@ Metadata:
     ParameterLabels:
       VPCCIDR:
         default: "VPC CIDR"
-      # Route53HostedZoneID:
-      #   default: "Route 53 hosted zone"
+      Route53HostedZoneID:
+        default: "Route 53 hosted zone"
       ProvisioningVolume:
         default: "Provisioning volume"
       DomainName:
@@ -40,10 +40,11 @@ Parameters:
     Type: String
     Default: 10.0.0.0/16
     Description: A CIDR block for the VPC to be created.
-  # Route53HostedZoneID:
-  #   Type: "AWS::Route53::HostedZone::Id"
-  #   Description: >-
-  #     The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB endpoint.
+  Route53HostedZoneID:
+    Type: "AWS::Route53::HostedZone::Id"
+    Description: >-
+      The Route 53 hosted zone to use for creating DNS records for ACM validation and the ALB endpoint. Leave this
+      blank to create the required DNS records separately or with another DNS provider.
   ProvisioningVolume:
     Type: String
     Description: >-
@@ -59,8 +60,8 @@ Parameters:
     Type: String
     Default: scim.example.com
     Description: >-
-      A fully qualified domain name for your SCIM bridge that is in the domain of the selected Route 53 hosted zone
-      where the record will be created.
+      A fully qualified domain name for your SCIM bridge. This must be in the domain of the Route 53 hosted
+      zone if it is specified.
   scimsession:
     Type: String
     Description: >-
@@ -127,6 +128,10 @@ Mappings:
       Redis: 512
       Task: 4096
 Conditions:
+  CreateRoute53Records: !Not
+    - !Equals [!Ref Route53HostedZoneID, ""]
+  OutputDNSRecordContent: !Not
+    - Condition: CreateRoute53Records
   UsingGoogleWorkspace: !Not
     - !Or
       - !Equals [!Ref WorkspaceCredentials, ""]
@@ -463,16 +468,17 @@ Resources:
                   - "logs:CreateLogStream"
                   - "logs:PutLogEvents"
                 Resource: "*"
-  # DNSRecord:
-  #   Type: "AWS::Route53::RecordSet"
-  #   Properties:
-  #     HostedZoneId: !Ref Route53HostedZoneID
-  #     Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
-  #     Name: !Ref DomainName
-  #     Type: A
-  #     AliasTarget:
-  #       DNSName: !GetAtt LoadBalancer.DNSName
-  #       HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+  DNSRecord:
+    Type: "AWS::Route53::RecordSet"
+    Condition: CreateRoute53Records
+    Properties:
+      HostedZoneId: !Ref Route53HostedZoneID
+      Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
+      Name: !Ref DomainName
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt LoadBalancer.DNSName
+        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
   TLSCertificate:
     Type: "AWS::CertificateManager::Certificate"
     Properties:
@@ -480,8 +486,14 @@ Resources:
       ValidationMethod: DNS
       DomainValidationOptions:
         - DomainName: !Ref DomainName
-          ValidationDomain: !Ref DomainName
-          # HostedZoneId: !Ref Route53HostedZoneID
+          ValidationDomain: !If
+              - OutputDNSRecordContent
+              - !Ref DomainName
+              - !Ref "AWS::NoValue"
+          HostedZoneId: !If
+              - CreateRoute53Records
+              - !Ref Route53HostedZoneID
+              - !Ref "AWS::NoValue"
   TaskRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -599,3 +611,15 @@ Outputs:
       The URL for your SCIM bridge. Use this and your bearer token to connect
       your identity provider to 1Password.
     Value: !Sub "https://${DomainName}"
+  CNAMEName:
+    Condition: OutputDNSRecordContent
+    Description: >-
+      Name of the public record that must be created to point to the DNS
+      name of the LoadBalancer resource.
+    Value: !Sub "${DomainName}."
+  CNAMEValue:
+    Condition: OutputDNSRecordContent
+    Description: >-
+      Value of the public record that must be created to point to the DNS
+      name of the LoadBalancer resource.
+    Value: !Sub "${LoadBalancer.DNSName}."

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -9,7 +9,7 @@ Metadata:
     ParameterGroups:
       - Parameters:
           - VPCCIDR
-          - Route53HostedZoneID
+          # - Route53HostedZoneID
           - ProvisioningVolume
           - DomainName
           - SCIMBridgeVersion
@@ -23,8 +23,8 @@ Metadata:
     ParameterLabels:
       VPCCIDR:
         default: "VPC CIDR"
-      Route53HostedZoneID:
-        default: "Route 53 hosted zone"
+      # Route53HostedZoneID:
+      #   default: "Route 53 hosted zone"
       ProvisioningVolume:
         default: "Provisioning volume"
       DomainName:
@@ -40,10 +40,10 @@ Parameters:
     Type: String
     Default: 10.0.0.0/16
     Description: A CIDR block for the VPC to be created.
-  Route53HostedZoneID:
-    Type: "AWS::Route53::HostedZone::Id"
-    Description: >-
-      The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB endpoint.
+  # Route53HostedZoneID:
+  #   Type: "AWS::Route53::HostedZone::Id"
+  #   Description: >-
+  #     The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB endpoint.
   ProvisioningVolume:
     Type: String
     Description: >-
@@ -151,7 +151,7 @@ Resources:
         Fn::Base64: !Sub |
           {
             "actor":"${WorkspaceActor}",
-            "bridgeAddress":"https://${DNSRecord}"
+            "bridgeAddress":"https://${DomainName}"
           }
 
   ECSCluster:
@@ -467,24 +467,25 @@ Resources:
                   - "logs:CreateLogStream"
                   - "logs:PutLogEvents"
                 Resource: "*"
-  DNSRecord:
-    Type: "AWS::Route53::RecordSet"
-    Properties:
-      HostedZoneId: !Ref Route53HostedZoneID
-      Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
-      Name: !Ref DomainName
-      Type: A
-      AliasTarget:
-        DNSName: !GetAtt LoadBalancer.DNSName
-        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+  # DNSRecord:
+  #   Type: "AWS::Route53::RecordSet"
+  #   Properties:
+  #     HostedZoneId: !Ref Route53HostedZoneID
+  #     Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
+  #     Name: !Ref DomainName
+  #     Type: A
+  #     AliasTarget:
+  #       DNSName: !GetAtt LoadBalancer.DNSName
+  #       HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
   TLSCertificate:
     Type: "AWS::CertificateManager::Certificate"
     Properties:
-      DomainName: !Ref DNSRecord
+      DomainName: !Ref DomainName
       ValidationMethod: DNS
       DomainValidationOptions:
-        - DomainName: !Ref DNSRecord
-          HostedZoneId: !Ref Route53HostedZoneID
+        - DomainName: !Ref DomainName
+          ValidationDomain: !Ref DomainName
+          # HostedZoneId: !Ref Route53HostedZoneID
   TaskRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -601,4 +602,4 @@ Outputs:
     Description: >-
       The URL for your SCIM bridge. Use this and your bearer token to connect
       your identity provider to 1Password.
-    Value: !Sub "https://${DNSRecord}"
+    Value: !Sub "https://${DomainName}"


### PR DESCRIPTION
Our current CloudFormation template automates DNS record management using Amazon Route 53 for the records that are required:

- to valid ownership of the domain used with AWS Certificate Manager (ACM) to request a TLS certificate presented by the load balancer
- to point from the domain name in this certificate to the load balancer IP address

In this PR, we will enhance our CloudFormation template to enable customers to deploy 1Password SCIM bridge by creating these records in another DNS provider.

The initial commit on this branch modifies the existing template to exclude the Route 53 resources, refactor references to it and its attributes, and enable manual rather than automated record creation for ACM validation. It currently works as expected for this use case.

Criteria for graduating from draft:

- ensure refactored references work as expected when re-enabling Route 53 resources for the "general" use case
- enable a means to optionally disable creation of Route 53 resources and automatically provide correct attributes for the ACM Certificate resource (e.g. if Route 53 Zone is *not* selected)
- add any necessary validation
- include a conditional output of the DNS record that must be created to point to the load balancer
- test using CLI deployment
- update instructions in README accordingly