### PR TITLE
Azure Container Apps Deployment Improvements

### DIFF
--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -61,7 +61,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 2. Add the Azure Container App extension by running the following command: `az extension add --name containerapp --upgrade`
 3. Get a list of the available locations in your Azure account: `az account list-locations -o table`, verify that the region you want to deploy on [supports Azure Container Apps](https://azure.microsoft.com/en-ca/explore/global-infrastructure/products-by-region/?regions=all&products=container-apps), take note of the name field for the desired region. 
 
-    > Note: This command can be skipped if you already know the region you want to deploy to and if that region supports Container Apps. 
+    > **Note:** This command can be skipped if you already know the region you want to deploy to and if that region supports Container Apps. 
 
 4. Define variables for the deployment using the following example in the Cloud Shell, _(using the bash or PowerShell syntax for the commands)_.
 
@@ -90,7 +90,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 
 5. Create the resource group: 
 
-    > Note: this step can be skipped if you are using an existing Resource Group to deploy your SCIM bridge to.
+    > **Note:** this step can be skipped if you are using an existing Resource Group to deploy your SCIM bridge to.
 
    ```
    az group create --name $ResourceGroup --location $Location

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -136,10 +136,11 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 9. Deploy your SCIM bridge containers based off the template file:
 
     Upload the [aca-op-scim-bridge.yaml](aca-op-scim-bridge.yaml) file to the Cloud Shell:
-       - In a separate browser window, download the [aca-op-scim-bridge.yaml](aca-op-scim-bridge.yaml) (selecting the download icon from the top right) from our GitHub repository. 
-       - Click the “Upload/Download files” button and choose Upload.
-       - Find the `aca.op-scim-bridge.yaml` file that you saved to your computer and choose it.
+    - In a separate browser window, download the [aca-op-scim-bridge.yaml](aca-op-scim-bridge.yaml) (selecting the download icon from the top right) from our GitHub repository. 
+    - Click the “Upload/Download files” button and choose Upload.
+    - Find the `aca.op-scim-bridge.yaml` file that you saved to your computer and choose it.
 
+    Run the following command to deploy the Container App from the template file:
     ```bash
     az containerapp update --resource-group $ResourceGroup --name $ConAppName --yaml aca-op-scim-bridge.yaml --query properties.configuration.ingress.fqdn
     ```

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -127,11 +127,11 @@ Both methods need the Container App Extension added to the Azure tool of choice,
     Obtain the `.yaml` file for deploying your SCIM bridge: 
     - Using bash
     ```bash
-    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/aca-op-scim-bridge.yaml --output aca-op-scim-bridge.yaml --silent
+    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/beta/azure-container-apps/aca-op-scim-bridge.yaml --output aca-op-scim-bridge.yaml --silent
     ```
      - Using PowerShell 
     ```pwsh
-    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/aca-op-scim-bridge.yaml -OutFile aca-op-scim-bridge.yaml
+    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/beta/azure-container-apps/aca-op-scim-bridge.yaml -OutFile aca-op-scim-bridge.yaml
     ```
 
     Run the following command to deploy the Container App from the template file:
@@ -357,11 +357,11 @@ The following steps only apply if you use Google Workspace as your identity prov
     Obtain the `workspace-settings.json` file: 
     - Using bash
     ```bash
-    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/google-workspace/workspace-settings.json --output workspace-settings.json --silent
+    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/beta/azure-container-apps/google-workspace/workspace-settings.json --output workspace-settings.json --silent
     ```
      - Using PowerShell 
     ```pwsh
-    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/google-workspace/workspace-settings.json -OutFile workspace-settings.json
+    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/beta/azure-container-apps/google-workspace/workspace-settings.json -OutFile workspace-settings.json
     ```
 5. Edit the file in your editor of choice and fill in correct values for:
 	* **Actor**: the email address of the administrator in Google Workspace that the service account is acting on behalf of.

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -85,7 +85,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
         ```bash
         ResourceGroup="op-scim-bridge-rg"
         Location="canadacentral"
-        ContAppEnv="op-scim-bridge-con-app-env"
+        ConAppEnv="op-scim-bridge-con-app-env"
         ConAppName="op-scim-bridge-con-app"
         ```
 
@@ -93,7 +93,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
         ```pwsh
         $ResourceGroup="op-scim-bridge-rg"
         $Location="canadacentral"
-        $ContAppEnv="op-scim-bridge-con-app-env"
+        $ConAppEnv="op-scim-bridge-con-app-env"
         $ConAppName="op-scim-bridge-con-app"
         ```
 
@@ -108,7 +108,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 6. Create the Container App Environment:
 
    ```
-   az containerapp env create --name $ContAppEnv --resource-group $ResourceGroup --location $Location --enable-workload-profles false
+   az containerapp env create --name $ConAppEnv --resource-group $ResourceGroup --location $Location --enable-workload-profles false
    ```
 
 7. Upload your `scimsession` file to the Cloud Shell:
@@ -126,11 +126,11 @@ Both methods need the Container App Extension added to the Azure tool of choice,
     Create your Container App Secret:
     - Using bash
         ```bash
-        az containerapp create --resource-group $ResourceGroup --environment $ContAppEnv --name $ConAppName  --secrets scimsession="$(cat /home/$USER/scimsession | base64)"
+        az containerapp create --resource-group $ResourceGroup --environment $ConAppEnv --name $ConAppName  --secrets scimsession="$(cat /home/$USER/scimsession | base64)"
         ```
     - Using PowerShell 
         ```pwsh
-        az containerapp create --resource-group $ResourceGroup --environment $ContAppEnv --name $ConAppName  --secrets scimsession="$([Convert]::ToBase64String([IO.File]::ReadAllBytes((Join-Path /home/$Env:USER/ 'scimsession'))) )"
+        az containerapp create --resource-group $ResourceGroup --environment $ConAppEnv --name $ConAppName  --secrets scimsession="$([Convert]::ToBase64String([IO.File]::ReadAllBytes((Join-Path /home/$Env:USER/ 'scimsession'))) )"
         ```
 
 9. Deploy your SCIM bridge containers based off the template file:
@@ -159,7 +159,7 @@ If you would prefer to create the two containers using the AZ CLI container apps
     az containerapp create -n $ConAppName -g $ResourceGroup \
     --container-name op-scim-bridge \
     --image docker.io/1password/scim:v2.8.4 \
-    --environment $ContAppEnv \
+    --environment $ConAppEnv \
     --ingress external --target-port 3002 \
     --cpu 0.25 --memory 0.5Gi \
     --min-replicas 1 --max-replicas 1 \
@@ -171,7 +171,7 @@ If you would prefer to create the two containers using the AZ CLI container apps
     az containerapp create -n $ConAppName -g $ResourceGroup `
     --container-name op-scim-bridge `
     --image docker.io/1password/scim:v2.8.4 `
-    --environment $ContAppEnv `
+    --environment $ConAppEnv `
     --ingress external --target-port 3002 `
     --cpu 0.25 --memory 0.5Gi `
     --min-replicas 1 --max-replicas 1 `

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -353,13 +353,19 @@ The following steps only apply if you use Google Workspace as your identity prov
    - Click the “Upload/Download files” button and choose Upload.
    - Find the `<keyfile>.json` file that you saved to your computer and choose it.
    - Make a note of the upload destination, then click Complete.
-4. Edit the file located at `./google-workspace/workspace-settings.json` and fill in correct values for:
+4. Obtain the `./google-workspace/workspace-settings.json`  file for editing: 
+    Obtain the `workspace-settings.json` file: 
+    - Using bash
+    ```bash
+    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/google-workspace/workspace-settings.json --output workspace-settings.json --silent
+    ```
+     - Using PowerShell 
+    ```pwsh
+    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/google-workspace/workspace-settings.json -OutFile workspace-settings.json
+    ```
+5. Edit the file in your editor of choice and fill in correct values for:
 	* **Actor**: the email address of the administrator in Google Workspace that the service account is acting on behalf of.
 	* **Bridge Address**: the URL you will use for your SCIM bridge (not your 1Password account sign-in address). This is the Application URL for your Container App found on the overview page. For example: https://scim.example.com.
-5. Upload your `workspace-settings.json` file to the Cloud Shell:
-   - Click the “Upload/Download files” button and choose Upload.
-   - Find the `workspace-settings.json` file that you saved to your computer and choose it.
-   - Make a note of the upload destination, then click Complete.
 6. Run the following command, replacing `$ConAppName` and `$ResourceGroup` with the names from your deployment to create the workspace-credentials secret. 
 
     - Using bash:

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -124,17 +124,22 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 
 9. Deploy your SCIM bridge containers based off the template file:
 
-    Upload the [aca-op-scim-bridge.yaml](aca-op-scim-bridge.yaml) file to the Cloud Shell:
-    - In a separate browser window, download the [aca-op-scim-bridge.yaml](aca-op-scim-bridge.yaml) (selecting the download icon from the top right) from our GitHub repository. 
-    - Click the “Upload/Download files” button and choose Upload.
-    - Find the `aca.op-scim-bridge.yaml` file that you saved to your computer and choose it.
+    Obtain the `.yaml` file for deploying your SCIM bridge: 
+    - Using bash
+    ```bash
+    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/aca-op-scim-bridge.yaml --output aca-op-scim-bridge.yaml --silent
+    ```
+     - Using PowerShell 
+    ```pwsh
+    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/bb/aca-yaml/beta/azure-container-apps/aca-op-scim-bridge.yaml -OutFile aca-op-scim-bridge.yaml
+    ```
 
     Run the following command to deploy the Container App from the template file:
     ```bash
     az containerapp update --resource-group $ResourceGroup --name $ConAppName --yaml aca-op-scim-bridge.yaml --query properties.configuration.ingress.fqdn
     ```
 
-10. Open the domain name listed in a separate browser tab to test your connection. You can sign in to your SCIM bridge using your bearer token.
+10. Copy the URL presented to log into your SCIM bridge in a separate browser tab to test your connection. You will need to access the page with `https://` for example `https://SCIMBridgeContainerAppURL.azurecontainerapps.io`. You can sign in to your SCIM bridge using your bearer token.
 
 ### Follow the steps to connect your Identity provider to the SCIM bridge.
  - [Connect your Identity Provider](https://support.1password.com/scim/#step-3-connect-your-identity-provider)
@@ -194,7 +199,8 @@ If you would prefer to create the two containers using the AZ CLI container apps
     --query properties.configuration.ingress.fqdn
     ```
 
-3. Open the domain name listed in a separate browser tab to test your connection. You can sign in to your SCIM bridge using your bearer token.
+3. Copy the URL presented to log into your SCIM bridge in a separate browser tab to test your connection. You will need to access the page with `https://` for example `https://SCIMBridgeContainerAppURL.azurecontainerapps.io`. You can sign in to your SCIM bridge using your bearer token.
+
 4. [Connect your Identity Provider](https://support.1password.com/scim/#step-3-connect-your-identity-provider).
 </details>
 

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -108,7 +108,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 6. Create the Container App Environment:
 
    ```
-   az containerapp env create --name $ConAppEnv --resource-group $ResourceGroup --location $Location --enable-workload-profles false
+   az containerapp env create --name $ConAppEnv --resource-group $ResourceGroup --location $Location --enable-workload-profiles false
    ```
 
 7. Upload your `scimsession` file to the Cloud Shell:
@@ -134,6 +134,11 @@ Both methods need the Container App Extension added to the Azure tool of choice,
         ```
 
 9. Deploy your SCIM bridge containers based off the template file:
+
+    Upload the [aca-op-scim-bridge.yaml](aca-op-scim-bridge.yaml) file to the Cloud Shell:
+       - In a separate browser window, download the [aca-op-scim-bridge.yaml](aca-op-scim-bridge.yaml) (selecting the download icon from the top right) from our GitHub repository. 
+       - Click the “Upload/Download files” button and choose Upload.
+       - Find the `aca.op-scim-bridge.yaml` file that you saved to your computer and choose it.
 
     ```bash
     az containerapp update --resource-group $ResourceGroup --name $ConAppName --yaml aca-op-scim-bridge.yaml --query properties.configuration.ingress.fqdn

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -144,7 +144,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 ### Follow the steps to connect your Identity provider to the SCIM bridge.
  - [Connect your Identity Provider](https://support.1password.com/scim/#step-3-connect-your-identity-provider)
 
-## Azure Container Apps Commands Deployment steps
+### Azure Container Apps Commands Deployment steps
 
 <details>
 <summary>Azure CLI Container Apps Commands Deployment steps</summary>

--- a/beta/azure-container-apps/ReadMe.md
+++ b/beta/azure-container-apps/ReadMe.md
@@ -25,9 +25,7 @@ The deployment consists of two [containers](https://learn.microsoft.com/en-us/az
 Deploying 1Password SCIM Bridge on Azure Container Apps comes with a few benefits:
 
 - For standard deployments, Azure Container Apps will host your SCIM bridge for ~$16 USD/month (when this document was written)
-  > **Note**
-  >
-  > Container Apps pricing is variable based on activity. Details can be found on [Microsoft's pricing page](https://azure.microsoft.com/en-us/pricing/details/container-apps/).
+  > **Note:** Container Apps pricing is variable based on activity. Details can be found on [Microsoft's pricing page](https://azure.microsoft.com/en-us/pricing/details/container-apps/).
 - No manual DNS record creation required. Azure Container Apps automatically provides a unique DNS record for your SCIM bridge URL.
 - Azure Container Apps automatically handles TLS certificate management on your behalf.
 - You will deploy 1Password SCIM Bridge directly to Azure from your Azure Portal or some commands can be performed from your local terminal. There is no requirement to clone this repository for this deployment.
@@ -35,13 +33,9 @@ Deploying 1Password SCIM Bridge on Azure Container Apps comes with a few benefit
 ## Prerequisites
 
 - A 1Password account with an active 1Password Business subscription or trial
-  > **Note**
-  >
-  > Try 1Password Business free for 14 days: <https://start.1password.com/sign-up/business>
+  > **Note:** Try 1Password Business free for 14 days: <https://start.1password.com/sign-up/business>
 - An Azure account with permissions to create a Container App.
-  > **Note**
-  >
-  > If you don't have a Azure account, you can sign up for a free trial with starting credit: <https://azure.microsoft.com/en-us/free/>
+  > **Note:** If you don't have a Azure account, you can sign up for a free trial with starting credit: <https://azure.microsoft.com/en-us/free/>
 - [Azure CLI tool](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) with the ContainerApp Extension or access to the [Azure Cloud Shell](https://learn.microsoft.com/en-us/azure/cloud-shell/quickstart) if performing the command driven deployment.
 
 ## Getting started
@@ -71,13 +65,10 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 
 4. Define variables for the deployment using the following example in the Cloud Shell, _(using the bash or PowerShell syntax for the commands)_.
 
-    > **Note**
-    >
-    >The ConAppName can contain lowercase letters, numerals, and hyphens. It must be between 2 and 32 characters long, and cannot start or end with a hyphen.
+    > **Note:** The ConAppName can contain lowercase letters, numerals, and hyphens. It must be between 2 and 32 characters long, and cannot start or end with a hyphen.
     > 
     > The location utilizes the name field of the `az account list-locations` command. 
     > Not all Azure locations support Conatiner Apps. See [supported regions for Azure Container Apps](https://azure.microsoft.com/en-ca/explore/global-infrastructure/products-by-region/?regions=all&products=container-apps)
-    >
 
     Update the values in a text editor before pasting it into the terminal, (If you have an existing Resource Group you want to use, specify the name in the ResourceGroup variable below):
 
@@ -118,9 +109,7 @@ Both methods need the Container App Extension added to the Azure tool of choice,
 
 8. Deploy the Container App Secret for the SCIM bridge. 
 
-    > **Note**
-    >
-    > If you prefer to deploy the containers using the Azure Container App Commands, go to this section: [Azure ContainerApps Commands Deployment steps](#azure-container-apps-commands-deployment-steps), othersise follow the template file steps below. 
+    > **Note:** If you prefer to deploy the containers using the Azure Container App Commands, go to this section: [Azure ContainerApps Commands Deployment steps](#azure-container-apps-commands-deployment-steps), othersise follow the template file steps below. 
     >
 
     Create your Container App Secret:
@@ -220,9 +209,7 @@ If you would prefer to create the two containers using the AZ CLI container apps
 
 The `scimsession` credentials will be saved as a secret variable in Container App. These credentials have to be Base64-encoded to pass them into the environment, but they're saved as a plain-text file when you download them or save in 1Password during the setup.
 
-> **Note**
-    >
-    >You will need to update the path to the scimsession file you download in the getting started section.
+> **Note:** You will need to update the path to the scimsession file you download in the getting started section.
 
 1. Get the Base64 encoded contents of your `scimsession` file, _(using the bash or PowerShell syntax for the commands)_: 
    

--- a/beta/azure-container-apps/aca-op-scim-bridge.yaml
+++ b/beta/azure-container-apps/aca-op-scim-bridge.yaml
@@ -1,0 +1,39 @@
+type: Microsoft.App/containerApps
+name: op-scim-bridge
+tags:
+  purpose: "1Password SCIM Bridge"
+properties:
+  configuration:
+    activeRevisionsMode: Single
+    ingress:
+      external: true
+      allowInsecure: false
+      targetPort: 3002
+      traffic:
+        - latestRevision: true
+          weight: 100
+      transport: Auto
+  template:
+    containers:
+      - image: docker.io/1password/scim:v2.8.4
+        name: op-scim-bridge
+        env:
+          - name: OP_REDIS_URL
+            value: "redis://localhost:6379"
+          - name: OP_SESSION
+            secretRef: scimsession
+        resources:
+          cpu: 0.25
+          memory: 0.5Gi
+      - image: docker.io/redis
+        name: op-scim-redis
+        env:
+          - name: REDIS_ARGS
+            value: "--maxmemory 256mb --maxmemory-policy volatile-lru"
+        resources:
+          cpu: 0.25
+          memory: 0.5Gi
+    scale:
+      minReplicas: 1
+      maxReplicas: 1
+      

--- a/beta/azure-container-apps/aca-op-scim-bridge.yaml
+++ b/beta/azure-container-apps/aca-op-scim-bridge.yaml
@@ -1,5 +1,5 @@
 type: Microsoft.App/containerApps
-name: op-scim-bridge
+name: op-scim-bridge-con-app
 tags:
   purpose: "1Password SCIM Bridge"
 properties:


### PR DESCRIPTION
Overall improvements to the Azure Container App deployment guide.

* Adding support for deploying the 1Password SCIM Bridge to Azure Container apps using a YAML file. 
  * Prioritizing the `yaml` deployment over the `az containerapp create` commands for separate containers. 
  * Keeping the commands available in the guide for anybody who wants to still created based off the commands.
* Shortening environment variable names to simply and shorten commands used during deployment
* Clarity on some administrative steps.
* Adding `--enable-workload-profiles false` to the `az containerapp env create` command to accommodate the [change made by Azure on December 5th version 2.55.0](https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli#containerapp-1) in the AZ CLI tooling. 
