### PR TITLE
the scim docker image now supports amd64/arm64 architectures

### DIFF
--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -18,7 +18,7 @@ The open source Docker Engine tooling can be used to deploy 1Password SCIM Bridg
 
 ## Prerequisites
 
-- AMD64 VM or bare metal server with a Docker-supported Linux distribution (e.g. Ubuntu, Debian, Fedora, etc.)
+- AMD64/ARM64 VM or bare metal server with a Docker-supported Linux distribution (e.g. Ubuntu, Debian, Fedora, etc.)
 - Docker Engine (see [Docker Engine installation overview](https://docs.docker.com/engine/install/#server)) installed on the Linux server
 - a public DNS A record pointing to the Linux server
 - SSH access to the Linux server


### PR DESCRIPTION
This is a very small documentation update to expand the architecture list that the scim bridge docker image supports.

The multiplatform scim image is targeted for release in January, 2024. [Follow this internal MR on gitlab for more information](https://gitlab.1password.io/dev/b5/op/-/merge_requests/3584).

We'll wait for that release to complete before merging this PR. 👍 