### PR TITLE
Replace deprecated aws_subnet_ids data source in aws-ecsfargate-terraform example

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -66,7 +66,7 @@ data "aws_vpc" "this" {
   tags    = var.vpc_name != "" ? { Name = var.vpc_name } : {}
 }
 
-data "aws_subnet_ids" "public" {
+data "aws_subnets" "public" {
   vpc_id = data.aws_vpc.this.id
   # Find the public subnets in the VPC
   tags = var.vpc_name != "" ? { SubnetTier = "public" } : {}
@@ -180,7 +180,7 @@ resource "aws_ecs_service" "op_scim_bridge" {
   }
 
   network_configuration {
-    subnets          = data.aws_subnet_ids.public.ids
+    subnets          = data.aws_subnets.public.ids
     assign_public_ip = true
     security_groups  = [aws_security_group.service.id]
   }
@@ -193,7 +193,7 @@ resource "aws_ecs_service" "op_scim_bridge" {
 resource "aws_alb" "op_scim_bridge" {
   name               = var.name_prefix == "" ? "op-scim-bridge-alb" : format("%s-%s", local.name_prefix, "alb")
   load_balancer_type = "application"
-  subnets            = data.aws_subnet_ids.public.ids
+  subnets            = data.aws_subnets.public.ids
   security_groups    = [aws_security_group.alb.id]
 
   tags = local.tags


### PR DESCRIPTION
Terraform has [deprecated aws_subnet_ids as of provider v4.0.0](https://github.com/hashicorp/terraform-provider-aws/issues/20592), which prevented the ecsfargate terraform example from provisioning.

The proposed changes on this PR have unblocked my particular rollout of the 1Password SCIM connector in AWS but *please note:* I have not tested all the possible ways that this change might affect other deployments.