### PR TITLE
Fix to Azure Container Apps workspace file

### DIFF
--- a/azure-container-apps/ReadMe.md
+++ b/azure-container-apps/ReadMe.md
@@ -316,7 +316,7 @@ az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim
 The following steps only apply if you use Google Workspace as your identity provider. If you use another identity provider, do not perform these steps.
 
 1. Follow the steps to [create a Google service account, key, and API client](https://support.1password.com/scim-google-workspace/#step-1-create-a-google-service-account-key-and-api-client).
-2. Start the Azure Cloud Shell from the navigation bar of your [Azure Portal](https://portal.azure.com) or directly open the [Azure Shell](https://shell.azure.com or use the `az` CLI tool..
+2. Start the Azure Cloud Shell from the navigation bar of your [Azure Portal](https://portal.azure.com) or directly open the [Azure Shell](https://shell.azure.com) or use the `az` CLI tool..
 3. Upload your `workspace-credentials.json`/`<keyfile>` file to the Cloud Shell:
    - Click the “Upload/Download files” button and choose Upload.
    - Find the `<keyfile>.json` file that you saved to your computer and choose it.

--- a/azure-container-apps/google-workspace/workspace-settings.json
+++ b/azure-container-apps/google-workspace/workspace-settings.json
@@ -1,0 +1,4 @@
+{
+    "actor":"admin.email.goes.here@example.com",
+    "bridgeAddress":"https://SCIMBridgeContainerAppURL.azurecontainerapps.io"
+}


### PR DESCRIPTION
Due to .gitignore, workspace-settings.json file was missed during beta promotion. 

Small markup formatting fix. 