### PR TITLE
Add tip callout to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # 1Password SCIM Bridge deployment examples
 
-You can deploy 1Password SCIM Bridge on any supported infrastructure that allows ingress by your identity provider and egress to 1Password servers. Here you'll find configuration files and best practices to help with your deployment. Learn more about [automating 1Password provisioning with SCIM](https://support.1password.com/scim/).
+You can deploy 1Password SCIM Bridge on any supported infrastructure that allows ingress by your identity provider and egress to 1Password servers. Here you'll find configuration files and best practices to help with your deployment.
+
+> [!TIP]
+> Before you deploy your SCIM bridge, learn more about [automating provisioning in 1Password using SCIM](https://support.1password.com/scim/).
 
 ## Marketplace apps
 


### PR DESCRIPTION
I'll be updating some of the other READMEs if we like the style. My Markdown editor just added support for rendering them so I noticed there are more types than I thought. GitHub calls these "alerts" and their documentation is here: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

What it looks like in preivew:

<img width="1056" alt="Screenshot 2024-01-30 at 9 20 07 AM" src="https://github.com/1Password/scim-examples/assets/6487393/0ccf5591-03ca-4fee-83b3-34d3f3598f42">
