### PR TITLE
Move Azure Container Apps to mounted secrets for all deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Before you begin deploying 1Password SCIM Bridge, review the [Preparation Guide]
 
 Containers as a service (CaaS) can simplify your deployment by using the built-in tools of the CaaS for DNS and certificate management. This gives you an easy, low-cost SCIM bridge with minimal infrastructure management requirements.
 
-- [Azure Container Apps](https://support.1password.com/scim-deploy-azure/)
-  - [Container Apps advanced references](/azure-container-apps)
+- Azure Container Apps
+  - [Azure Container Apps Deployment](https://support.1password.com/scim-deploy-azure/) - recommended for most Azure Container App deployments
+  - [Container Apps Azure Portal Deployment](/azure-container-apps/README.md) - recommended for those not able to use the tools in the above deployment guide
+  - [Container Apps advanced customizations](/azure-container-apps/ADVANCED.md)
 - DigitalOcean App Platform 
-  - [Using DigitalOcean Portal](https://support.1password.com/cs/scim-deploy-digitalocean-ap/)
-  - [Using DigitalOcean command line tool & the 1Password CLI](/do-app-platform-op-cli) 
+  - [DigitalOcean Portal Deployment](https://support.1password.com/cs/scim-deploy-digitalocean-ap/)
+  - [DigitalOcean command line tool & the 1Password CLI Deployment](/do-app-platform-op-cli) 
 
 ### Advanced deployment options
 If you have particular requirements for your environment, we recommend an advanced deployment. These example configurations will give you a base to create the deployment from, as well as explain what 1Password SCIM Bridge needs to function and how to maintain your bridge once you've deployed it.

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -2,7 +2,7 @@
 
 _Learn how to deploy 1Password SCIM Bridge on the [Azure Container Apps](https://azure.microsoft.com/en-us/products/container-apps/#overview) service._
 
-This deployment consists of two [containers](https://learn.microsoft.com/en-us/azure/container-apps/containers): One for the SCIM bridge and another for Redis. There's also an [ingress](https://learn.microsoft.com/en-us/azure/container-apps/ingress-overview) for the SCIM bridge container. There are a few benefits to deploying 1Password SCIM Bridge on Azure Container Apps:
+This guide goes into more advanced cusomtizations or configurations for the Azure Container App deployment of your 1Password SCIM Bridge. There are a few benefits to deploying 1Password SCIM Bridge on Azure Container Apps:
 
 - **Low cost:** For standard deployments, the service will host your SCIM bridge for ~$16 USD/month (as of January 2024). Container Apps pricing is variable based on activity, and you can learn more on [Microsoft's pricing page](https://azure.microsoft.com/en-us/pricing/details/container-apps/).
 - **Automatic DNS record management:** You don't need to manage a DNS record. Azure Container Apps automatically provides a unique one for your SCIM bridge domain.
@@ -11,20 +11,11 @@ This deployment consists of two [containers](https://learn.microsoft.com/en-us/a
 
 **Table of contents:**
 
-- [Update your SCIM Bridge](#update-your-scim-bridge-in-the-azure-cloud-shell)
 - [Resource recommendations](#resource-recommendations)
 - [Customize your deployment](#customize-your-deployment)
 - [Get help](#get-help)
+- [Updating your SCIM Bridge](#updating-your-scim-bridge-in-the-azure-cloud-shell)
 - [Connect Google Workspace as your IdP](#if-google-workspace-is-your-identity-provider)
-
-## Update your SCIM bridge in the Azure Cloud Shell
-
-> [!TIP]
-> Check for 1Password SCIM Bridge updates on the [SCIM bridge release page](https://app-updates.agilebits.com/product_history/SCIM).
-
-1. Follow the steps on our [SCIM bridge Update guide](https://support.1password.com/scim-update/#azure-container-apps).
-
-After you sign in to your SCIM bridge, the [Automated User Provisioning page](https://start.1password.com/integrations/active/) in your 1Password account will also update with the latest access time and SCIM bridge version.
 
 ## Resource recommendations
 
@@ -36,7 +27,7 @@ The pod for 1Password SCIM Bridge should be vertically scaled if you provision a
 | High      | 1,000–5,000     | 0.5   | 1.0Gi  |
 | Very high | >5,000          | 1.0   | 1.0Gi  |
 
-If you're provisioning more than 1,000 users, update the resources assigned to [the SCIM bridge container](#22-continue-creating-the-container-app) to follow these recommendations. The resources specified for the Redis container don't need to be adjusted.
+If you're provisioning more than 1,000 users, update the resources assigned to the SCIM bridge container to follow these recommendations. The resources specified for the Redis container don't need to be adjusted.
 
 > [!TIP]
 > Learn more about [Container App Name (`ConAppName`) variable requirements](#container-app-name-requirements) that are referenced in the commands below. Copy the following command to a text editor and replace `$ConAppName` and `$ResourceGroup` with the names from your deployment similar to how you did originally in our [deployment guide](https://support.1password.com/scim-deploy-azure/#22-define-variables). 
@@ -258,6 +249,15 @@ Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ C
 4. Open your SCIM bridge URL in a browser and enter your bearer token to test the bridge.
 
 5. Update your identity provider configuration with the new bearer token.
+
+### Updating your SCIM bridge in the Azure Cloud Shell
+
+> [!TIP]
+> Check for 1Password SCIM Bridge updates on the [SCIM bridge release page](https://app-updates.agilebits.com/product_history/SCIM).
+
+1. Follow the steps on our [SCIM bridge Update guide](https://support.1password.com/scim-update/#azure-container-apps).
+
+After you sign in to your SCIM bridge, the [Automated User Provisioning page](https://start.1password.com/integrations/active/) in your 1Password account will also update with the latest access time and SCIM bridge version.
 
 ## If Google Workspace is your identity provider
 

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -1,4 +1,4 @@
-# Advanced Options for your 1Password SCIM Bridge on Azure Container Apps
+# Advanced details for your 1Password SCIM Bridge on Azure Container Apps
 
 _Learn how to deploy 1Password SCIM Bridge on the [Azure Container Apps](https://azure.microsoft.com/en-us/products/container-apps/#overview) service._
 
@@ -12,7 +12,8 @@ This deployment consists of two [containers](https://learn.microsoft.com/en-us/a
 **Table of contents:**
 
 - [Update your SCIM Bridge](#update-your-scim-bridge-in-the-azure-cloud-shell)
-- [Resource recommendations](#appendix-resource-recommendations)
+- [Resource recommendations](#resource-recommendations)
+- [Customize your deployment](#customize-your-deployment)
 - [Get help](#get-help)
 - [Connect Google Workspace as your IdP](#if-google-workspace-is-your-identity-provider)
 
@@ -25,7 +26,7 @@ This deployment consists of two [containers](https://learn.microsoft.com/en-us/a
 
 After you sign in to your SCIM bridge, the [Automated User Provisioning page](https://start.1password.com/integrations/active/) in your 1Password account will also update with the latest access time and SCIM bridge version.
 
-## Appendix: Resource recommendations
+## Resource recommendations
 
 The pod for 1Password SCIM Bridge should be vertically scaled if you provision a large number of users or groups. These are our default resource specifications and recommended configurations for provisioning at scale:
 
@@ -38,15 +39,14 @@ The pod for 1Password SCIM Bridge should be vertically scaled if you provision a
 If you're provisioning more than 1,000 users, update the resources assigned to [the SCIM bridge container](#22-continue-creating-the-container-app) to follow these recommendations. The resources specified for the Redis container don't need to be adjusted.
 
 > [!TIP]
-> Learn more about [Container App Name (`ConAppName`) variable requirements](#container-app-name-requirements) that are referenced in the commands below. Copy the following command to a text editor and replace `$ConAppName` and `$ResourceGroup` with the names from your deployment.
+> Learn more about [Container App Name (`ConAppName`) variable requirements](#container-app-name-requirements) that are referenced in the commands below. Copy the following command to a text editor and replace `$ConAppName` and `$ResourceGroup` with the names from your deployment similar to how you did originally in our [deployment guide](https://support.1password.com/scim-deploy-azure/#22-define-variables). 
 
 ### Default deployment
 
 If you're provisioning up to 1,000 users, run the following command to reset the specs back to the default:
 
-```sh
-az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge \
-  --cpu 0.25 --memory 0.5Gi
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --cpu 0.25 --memory 0.5Gi
 ```
 
 To udpate back to the defaults within the Azure Portal: 
@@ -61,9 +61,8 @@ To udpate back to the defaults within the Azure Portal:
 
 If you're provisioning between 1,000 and 5,000 users, run the following command:
 
-```sh
-az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge \
-  --cpu 0.5 --memory 1.0Gi
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --cpu 0.5 --memory 1.0Gi
 ```
 
 To udpate to the high-volume within the Azure Portal: 
@@ -78,9 +77,8 @@ To udpate to the high-volume within the Azure Portal:
 
 If you're provisioning more than 5,000 users, run the following command:
 
-```sh
-az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge \
-  --cpu 1.0 --memory 1.0Gi
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --cpu 1.0 --memory 1.0Gi
 ```
 
 To udpate to the very high-volume within the Azure Portal: 
@@ -90,6 +88,101 @@ To udpate to the very high-volume within the Azure Portal:
 3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
 4. Set the **CPU cores** to `1.0` and the **Memory (Gi)** to `1.0`.
 5. Click **Save**, then click **Create**.
+
+## Customize your deployment
+
+> [!TIP]
+> Copy the following command(s) below to set certain enviornment variables, define these variables again to align to your deployment similar to how you did originally in our [deployment guide](https://support.1password.com/scim-deploy-azure/#22-define-variables). 
+> Alternatively you can add the environment variables through Azure Portal as detailed below.
+
+### Confirmation Interval
+
+Use OP_CONFIRMATION_INTERVAL environment variable to set how often the ConfirmationWatcher component runs in seconds. The minimum
+interval is 30 seconds. If not set, the default value of 300 seconds (5 minutes) is used.
+
+For example set `OP_CONFIRMATION_INTERVAL` to `30` to have the ConfirmationWatcher running every 30 seconds.
+
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --set-env-vars OP_CONFIRMATION_INTERVAL=30
+```
+
+To udpate within the Azure Portal: 
+
+1. Within Container App from the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
+2. Click **Edit and deploy**.
+3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
+4. Add a new **Environment variable**, using the **name** of `OP_CONFIRMATION_INTERVAL`, the **source** of **Manual entry** and enter the time in seconds for the **value**
+5. Click **Save**, then click **Create**.
+
+### Colorful logs
+
+Use OP_PRETTY_LOGS environment variable to set `OP_PRETTY_LOGS` to `1` to colorize container logs.
+
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --set-env-vars OP_PRETTY_LOGS=1
+```
+
+To udpate within the Azure Portal: 
+
+1. Within Container App from the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
+2. Click **Edit and deploy**.
+3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
+4. Add a new **Environment variable**, using the **name** of `OP_PRETTY_LOGS`, the **source** of **Manual entry** and enter `1` for the **value**
+5. Click **Save**, then click **Create**.
+
+### JSON logs
+
+By default, container logs are output in a human-readable format. Set the environment variable `OP_JSON_LOGS` to `1` for newline-delimited JSON logs.
+
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --set-env-vars OP_JSON_LOGS=1
+```
+
+To udpate within the Azure Portal: 
+
+1. Within Container App from the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
+2. Click **Edit and deploy**.
+3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
+4. Add a new **Environment variable**, using the **name** of `OP_JSON_LOGS`, the **source** of **Manual entry** and enter `1` for the **value**
+5. Click **Save**, then click **Create**.
+
+This can be useful for capturing structured logs.
+
+### Debug logs
+
+Set the environment variable `OP_DEBUG` to `1` to enable debug level logging:
+
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --set-env-vars OP_DEBUG=1
+```
+
+To udpate within the Azure Portal: 
+
+1. Within Container App from the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
+2. Click **Edit and deploy**.
+3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
+4. Add a new **Environment variable**, using the **name** of `OP_DEBUG`, the **source** of **Manual entry** and enter `1` for the **value**
+5. Click **Save**, then click **Create**.
+
+This may be useful for troubleshooting, or when contacting 1Password Support.
+
+### Trace logs
+
+Set the environment variable `OP_TRACE` to `1` to enable trace level debug output in the logs:
+
+```bash
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --set-env-vars OP_TRACE=1
+```
+
+To udpate within the Azure Portal: 
+
+1. Within Container App from the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
+2. Click **Edit and deploy**.
+3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
+4. Add a new **Environment variable**, using the **name** of `OP_TRACE`, the **source** of **Manual entry** and enter `1` for the **value**
+5. Click **Save**, then click **Create**.
+
+This may be useful for troubleshooting Let’s Encrypt integration issues.
 
 ## Get help
 
@@ -127,7 +220,7 @@ After you download a new `scimsession` file, follow the steps below to replace t
 Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ CLI
 
 > The following steps assume you have moved to mounting your secret from a volume mount and not using the base64 value in your secrets. 
-> Follow the [command to update your deployment with the updated YAML file](https://support.1password.com/scim-deploy-azure/#step-3-set-up-and-deploy-1password-scim-bridge) to use a volume mounts, redefining your variables as needed for this command to succeed. 
+> Follow the [command to update your deployment with the updated YAML file](https://support.1password.com/scim-deploy-azure/#step-3-set-up-and-deploy-1password-scim-bridge) to use volume mounts, redefining your variables as needed for this command to succeed. 
 
 
 1. Open the [Azure Shell](https://shell.azure.com) or use the `az` CLI tool.

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -97,7 +97,7 @@ To udpate to the very high-volume within the Azure Portal:
 
 ### Confirmation Interval
 
-Use OP_CONFIRMATION_INTERVAL environment variable to set how often the ConfirmationWatcher component runs in seconds. The minimum
+Use the OP_CONFIRMATION_INTERVAL environment variable to set how often the ConfirmationWatcher component runs in seconds. The minimum
 interval is 30 seconds. If not set, the default value of 300 seconds (5 minutes) is used.
 
 For example set `OP_CONFIRMATION_INTERVAL` to `30` to have the ConfirmationWatcher running every 30 seconds.
@@ -116,7 +116,7 @@ To udpate within the Azure Portal:
 
 ### Colorful logs
 
-Use OP_PRETTY_LOGS environment variable to set `OP_PRETTY_LOGS` to `1` to colorize container logs.
+Use the OP_PRETTY_LOGS environment variable to set `OP_PRETTY_LOGS` to `1` to colorize container logs.
 
 ```bash
 az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --set-env-vars OP_PRETTY_LOGS=1
@@ -182,7 +182,7 @@ To udpate within the Azure Portal:
 4. Add a new **Environment variable**, using the **name** of `OP_TRACE`, the **source** of **Manual entry** and enter `1` for the **value**
 5. Click **Save**, then click **Create**.
 
-This may be useful for troubleshooting Let’s Encrypt integration issues.
+This may be useful for troubleshooting issues.
 
 ## Get help
 

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -158,7 +158,7 @@ Follow the steps to [create a Google service account, key, and API client](https
 1. Follow the steps to [create a Google service account, key, and API client](https://support.1password.com/scim-google-workspace/#step-1-create-a-google-service-account-key-and-api-client).
 2. Open the [Azure Shell](https://shell.azure.com/) or open a new terminal window with the `az` CLI.
 3. Upload your `workspace-credentials.json/<keyfile>` file to the Cloud Shell. Click the **Upload/Download files** button in your Cloud Shell and choose **Upload**.
-4. Select the `<keyfile>.json` file that you saved to your computer
+4. Select the `<keyfile>.json` file that you saved to your computer. _It is recommended at this point to rename the file to `workspace-credentials.json` or make note of the filename to change the command used in [step 3](#step-3-create-your-google-workspace-secrets-and-update-your-scim-bridge-deployment)._
 5. Make note of the upload destination, then click **Complete**.
 
 #### Step 2: Download and edit the `workspace-settings.json` file
@@ -176,7 +176,10 @@ Follow the steps to [create a Google service account, key, and API client](https
     - **Actor**: Enter the email address of the Google Workspace administrator for the service account.
     - **Bridge Address**: Enter your SCIM bridge domain. This is the Application URL for your Container App, found on the overview page (not your 1Password account sign-in address). For example: `https://scim.example.com`.
 3. Save the file.
-4. Copy and paste the following command for your shell, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
+
+#### Step 3: Create your Google Workspace secrets and update your SCIM bridge deployment
+
+1. Copy and paste the following command for your shell, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
     - **Bash**:
     ```bash
     az containerapp secret set \
@@ -191,9 +194,18 @@ Follow the steps to [create a Google service account, key, and API client](https
     --resource-group $ResourceGroup `
     --secrets workspace-creds="$(Get-Content $HOME/workspace-credentials.json)" workspace-settings="$(Get-Content $HOME/workspace-settings.json)"
     ```
-5. To restart your SCIM bridge so it can use the new secret, copy and paste the following command. Replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
+2. To update your SCIM bridge so it can use the new secrets, copy and paste the following command. Replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
+    - **Bash**:
+    ```bash
+    curl --silent --show-error https://raw.githubusercontent.com/1Password/scim-examples/main/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml |
+    	az containerapp update --resource-group $ResourceGroup --name $ConAppName \
+		--yaml /dev/stdin --query properties.configuration.ingress.fqdn
     ```
-    az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --set-env-vars OP_WORKSPACE_CREDENTIALS=secretref:workspace-creds OP_WORKSPACE_SETTINGS=secretref:workspace-settings
+    - **PowerShell**:
+    ```pwsh
+    Invoke-RestMethod -Uri https://raw.githubusercontent.com/1Password/scim-examples/main/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml |
+		az containerapp update --resource-group $ResourceGroup --name $ConAppName `
+			--yaml /dev/stdin --query properties.configuration.ingress.fqdn
     ```
 
 </details>

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -153,60 +153,7 @@ Follow the steps to [create a Google service account, key, and API client](https
 <details>
 <summary>Connect Google Workspace using the Azure Cloud Shell or AZ CLI</summary>
 
-#### Step 1: Get your Google service account key
-
-1. Follow the steps to [create a Google service account, key, and API client](https://support.1password.com/scim-google-workspace/#step-1-create-a-google-service-account-key-and-api-client).
-2. Open the [Azure Shell](https://shell.azure.com/) or open a new terminal window with the `az` CLI.
-3. Upload your `workspace-credentials.json/<keyfile>` file to the Cloud Shell. Click the **Upload/Download files** button in your Cloud Shell and choose **Upload**.
-4. Select the `<keyfile>.json` file that you saved to your computer. _It is recommended at this point to rename the file to `workspace-credentials.json` or make note of the filename to change the command used in [step 3](#step-3-create-your-google-workspace-secrets-and-update-your-scim-bridge-deployment)._
-5. Make note of the upload destination, then click **Complete**.
-
-#### Step 2: Download and edit the `workspace-settings.json` file
-
-1. Run the following command for your shell to get the `./google-workspace/workspace-settings.json` file.
-    - **Bash**:
-    ```bash
-    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/azure-container-apps/google-workspace/workspace-settings.json --output workspace-settings.json --silent
-    ```
-    - **PowerShell**:
-    ```pwsh
-    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/azure-container-apps/google-workspace/workspace-settings.json -OutFile workspace-settings.json
-    ```
-2. Edit the following in the .json file:
-    - **Actor**: Enter the email address of the Google Workspace administrator for the service account.
-    - **Bridge Address**: Enter your SCIM bridge domain. This is the Application URL for your Container App, found on the overview page (not your 1Password account sign-in address). For example: `https://scim.example.com`.
-3. Save the file.
-
-#### Step 3: Create your Google Workspace secrets and update your SCIM bridge deployment
-
-1. Copy and paste the following command for your shell, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
-    - **Bash**:
-    ```bash
-    az containerapp secret set \
-    --name $ConAppName \
-    --resource-group $ResourceGroup \
-    --secrets workspace-creds="$(cat $HOME/workspace-credentials.json)" workspace-settings="$(cat $HOME/workspace-settings.json)"
-    ```
-    - **PowerShell**:
-    ```pwsh
-    az containerapp secret set `
-    --name $ConAppName `
-    --resource-group $ResourceGroup `
-    --secrets workspace-creds="$(Get-Content $HOME/workspace-credentials.json)" workspace-settings="$(Get-Content $HOME/workspace-settings.json)"
-    ```
-2. To update your SCIM bridge so it can use the new secrets, copy and paste the following command. Replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
-    - **Bash**:
-    ```bash
-    curl --silent --show-error https://raw.githubusercontent.com/1Password/scim-examples/main/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml |
-    	az containerapp update --resource-group $ResourceGroup --name $ConAppName \
-		--yaml /dev/stdin --query properties.configuration.ingress.fqdn
-    ```
-    - **PowerShell**:
-    ```pwsh
-    Invoke-RestMethod -Uri https://raw.githubusercontent.com/1Password/scim-examples/main/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml |
-		az containerapp update --resource-group $ResourceGroup --name $ConAppName `
-			--yaml /dev/stdin --query properties.configuration.ingress.fqdn
-    ```
+To connect Google Workspace using the Azure Cloud Shell or AZ CLI, follow the steps in our [Advanced guide](ADVANCED.md).
 
 </details>
 
@@ -238,117 +185,18 @@ The pod for 1Password SCIM Bridge should be vertically scaled if you provision a
 | High      | 1,000–5,000     | 0.5   | 1.0Gi  |
 | Very high | >5,000          | 1.0   | 1.0Gi  |
 
-If you're provisioning more than 1,000 users, update the resources assigned to [the SCIM bridge container](#22-continue-creating-the-container-app) to follow these recommendations. The resources specified for the Redis container don't need to be adjusted.
-
-> [!TIP]
-> Learn more about [Container App Name (`ConAppName`) variable requirements](#container-app-name-requirements) that are referenced in the commands below.
-
-### Default deployment
-
-If you're provisioning up to 1,000 users, run the following command:
-
-```sh
-az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge \
-  --cpu 0.25 --memory 0.5Gi
-```
-
-### High-volume deployment
-
-If you're provisioning between 1,000 and 5,000 users, run the following command:
-
-```sh
-az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge \
-  --cpu 0.5 --memory 1.0Gi
-```
-
-### Very high-volume deployment
-
-If you're provisioning more than 5,000 users, run the following command:
-
-```sh
-az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge \
-  --cpu 1.0 --memory 1.0Gi
-```
+If you're provisioning more than 1,000 users, update the resources assigned to [the SCIM bridge container](#22-continue-creating-the-container-app) to follow these recommendations. The resources specified for the Redis container don't need to be adjusted. Steps can be found on our [Advanced guide](ADVANCED.md) on how to update your resources.
 
 ## Get help
 
-### Region support
-
-When you create or deploy the Container App Environment, Azure may present an error that the region isn't supported. You can review Azure documentation to make sure the region you selected supports [Azure Container Apps](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?regions=all&products=container-apps).
-
-### Container App Operational Insights error
-
-Some customers receive an error when creating the Azure Container App Environment stating that the subscription is not registered for Microsoft.OperationalInsights resource provider. This error occurs if the Operational Insights which is used by Log Analytics workspace for Container Apps has never been enabled within the subscription. Run the command shown in the error: 
-```
-az provider register -n Microsoft.OperationalInsights --wait
-```
-Once the command is completed, you will need to re-run the [command to create the Container App Environment](https://support.1password.com/scim-deploy-azure/#24-create-the-container-app-environment) again, so the command completes successfully with the Log Analystics workspace. 
-
-### Container App working with multiple subscriptions
-
-If your are using an existing resource group or have multiple subsriptions within your Azure Cloud environment, you may receive errors stating that the subscription or the resource group can not be found. Use the following command to set your subscription within your Shell. Alternatively you can add the `--subscription <subsciptionIDorName>` to every `az` command.
-```
-az account set --subscription <subsciptionIDorName>
-```
-
-### Container App Name requirements
-
-Your Container App Name (the `ConAppName` variable) can contain lowercase letters, numbers, and hyphens. It must be 2 to 32 characters long, cannot start or end with a hyphen, and cannot start with a number. [Learn more about the naming rules and restrictions for Azure resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftapp).
-
-### Viewing logs in Azure Container Apps
-
-You can [view logs for a container app](https://learn.microsoft.com/azure/container-apps/log-streaming?tabs=bash#view-log-streams-via-the-azure-portal) in the **Log Stream** area of your environment or container app in the Azure portal. If you're having an issue starting up the SCIM bridge, reviewing the **op-scim-bridge** container logs can help you identify the problem.
+> [!TIP]
+> For more advanced tips follow the get help section in our [Advanced guide](ADVANCED.md).
 
 ### How to update the **scimsession** secret
 
 After you download a new `scimsession` file, follow the steps below to replace the secret in your Container App.
 
-<details>
-<summary>Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ CLI</summary>
-
-> The following steps assume you have moved to mounting your secret from a volume mount and not using the base64 value in your secrets. 
-> Follow the [command to update your deployment with the updated YAML file](https://support.1password.com/scim-deploy-azure/#step-3-set-up-and-deploy-1password-scim-bridge) to use a volume mounts, redefining your variables as needed for this command to succeed. 
-
-
-1. Open the [Azure Shell](https://shell.azure.com) or use the `az` CLI tool.
-
-2. Copy and paste the following command, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
-
-    - **Bash**:
-
-        ```bash
-        az containerapp secret set \
-            --name $ConAppName \
-            --resource-group $ResourceGroup \
-            --secrets scimsession="$(cat $HOME/scimsession)"
-        ```
-
-    - **PowerShell**:
-
-        ```pwsh
-        az containerapp secret set `
-            --name $ConAppName `
-            --resource-group $ResourceGroup `
-            --secrets scimsession="$(Get-Content $HOME/scimsession)"
-        ```
-
-3. Copy and paste the following command, which will have the `op-scim-bridge` container read the new secret. Replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, then run the command.
-    ```bash
-    az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --query properties.latestRevisionName
-    ```
-
-    Update the revsion name to use the output of the above command
-    ```
-    az containerapp revision restart -n $ConAppName -g $ResourceGroup --revision revisionName
-    ```
-
-4. Open your SCIM bridge URL in a browser and enter your bearer token to test the bridge.
-
-5. Update your identity provider configuration with the new bearer token.
-    </details>
-
-<details>
-<summary>Replace your <code>scimsession</code> secret using the Azure Portal</summary>
+Replace your <code>scimsession</code> secret using the Azure Portal
 
 1. Open the Azure Portal and go to the [Container Apps](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps) page.
 2. Choose **Secrets** from the Settings section in the sidebar.
@@ -358,4 +206,9 @@ After you download a new `scimsession` file, follow the steps below to replace t
 6. Click your current active revision and choose **Restart** in the details pane.
 7. Open your SCIM bridge URL in a browser and enter you new bearer token to test the bridge.
 8. Update your identity provider configuration with the new bearer token.
-    </details>
+
+<details>
+<summary>Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ CLI</summary>
+
+Using the Azure Cloud Shell or AZ CLI, follow the steps in our [Advanced guide](ADVANCED.md).
+</details>

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -190,7 +190,7 @@ If you're provisioning more than 1,000 users, update the resources assigned to [
 ## Get help
 
 > [!TIP]
-> For more advanced tips follow the get help section in our [Advanced guide](ADVANCED.md).
+> For more advanced tips follow the Customize your Deployment, or Get Help section in our [Advanced guide](ADVANCED.md).
 
 ### How to update the **scimsession** secret
 

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -276,6 +276,21 @@ az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim
 
 When you create or deploy the Container App Environment, Azure may present an error that the region isn't supported. You can review Azure documentation to make sure the region you selected supports [Azure Container Apps](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?regions=all&products=container-apps).
 
+### Container App Operational Insights error
+
+Some customers receive an error when creating the Azure Container App Environment stating that the subscription is not registered for Microsoft.OperationalInsights resource provider. This error occurs if the Operational Insights which is used by Log Analytics workspace for Container Apps has never been enabled within the subscription. Run the command shown in the error: 
+```
+az provider register -n Microsoft.OperationalInsights --wait
+```
+Once the command is completed, you will need to re-run the [command to create the Container App Environment](https://support.1password.com/scim-deploy-azure/#24-create-the-container-app-environment) again, so the command completes successfully with the Log Analystics workspace. 
+
+### Container App working with multiple subscriptions
+
+If your are using an existing resource group or have multiple subsriptions within your Azure Cloud environment, you may receive errors stating that the subscription or the resource group can not be found. Use the following command to set your subscription within your Shell. Alternatively you can add the `--subscription <subsciptionIDorName>` to every `az` command.
+```
+az account set --subscription <subsciptionIDorName>
+```
+
 ### Container App Name requirements
 
 Your Container App Name (the `ConAppName` variable) can contain lowercase letters, numbers, and hyphens. It must be 2 to 32 characters long, cannot start or end with a hyphen, and cannot start with a number. [Learn more about the naming rules and restrictions for Azure resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftapp).
@@ -291,8 +306,7 @@ After you download a new `scimsession` file, follow the steps below to replace t
 <details>
 <summary>Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ CLI</summary>
 
-> [!TIP]
-> The following steps assume you have moved to mounting your secret from a volume mount and not using the base64 value. 
+> The following steps assume you have moved to mounting your secret from a volume mount and not using the base64 value in your secrets. 
 > Follow the [command to update your deployment with the updated YAML file](https://support.1password.com/scim-deploy-azure/#step-3-set-up-and-deploy-1password-scim-bridge) to use a volume mounts, redefining your variables as needed for this command to succeed. 
 
 

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -182,14 +182,14 @@ Follow the steps to [create a Google service account, key, and API client](https
     az containerapp secret set \
     --name $ConAppName \
     --resource-group $ResourceGroup \
-    --secrets workspace-creds="$(cat $HOME/workspace-credentials.json | base64)"
+    --secrets workspace-creds="$(cat $HOME/workspace-credentials.json)" workspace-settings="$(cat $HOME/workspace-settings.json)"
     ```
     - **PowerShell**:
     ```pwsh
     az containerapp secret set `
     --name $ConAppName `
     --resource-group $ResourceGroup `
-    --secrets workspace-creds="$([Convert]::ToBase64String([IO.File]::ReadAllBytes((Join-Path $HOME 'workspace-credentials.json'))))"
+    --secrets workspace-creds="$(Get-Content $HOME/workspace-credentials.json)" workspace-settings="$(Get-Content $HOME/workspace-settings.json)"
     ```
 5. To restart your SCIM bridge so it can use the new secret, copy and paste the following command. Replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
     ```
@@ -279,6 +279,11 @@ After you download a new `scimsession` file, follow the steps below to replace t
 <details>
 <summary>Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ CLI</summary>
 
+> [!TIP]
+> The following steps assume you have moved to mounting your secret from a volume mount and not using the base64 value. 
+> Follow the [command to update your deployment with the updated YAML file](https://support.1password.com/scim-deploy-azure/#step-3-set-up-and-deploy-1password-scim-bridge) to use a volume mounts, redefining your variables as needed for this command to succeed. 
+
+
 1. Open the [Azure Shell](https://shell.azure.com) or use the `az` CLI tool.
 
 2. Copy and paste the following command, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
@@ -289,7 +294,7 @@ After you download a new `scimsession` file, follow the steps below to replace t
         az containerapp secret set \
             --name $ConAppName \
             --resource-group $ResourceGroup \
-            --secrets scimsession="$(cat $HOME/scimsession | base64)"
+            --secrets scimsession="$(cat $HOME/scimsession)"
         ```
 
     - **PowerShell**:
@@ -298,7 +303,7 @@ After you download a new `scimsession` file, follow the steps below to replace t
         az containerapp secret set `
             --name $ConAppName `
             --resource-group $ResourceGroup `
-            --secrets scimsession="$([Convert]::ToBase64String([IO.File]::ReadAllBytes((Join-Path $HOME 'scimsession'))))"
+            --secrets scimsession="$(Get-Content $HOME/scimsession)"
         ```
 
 3. Copy and paste the following command, which will have the `op-scim-bridge` container read the new secret. Replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, then run the command.

--- a/azure-container-apps/aca-op-scim-bridge.yaml
+++ b/azure-container-apps/aca-op-scim-bridge.yaml
@@ -17,11 +17,9 @@ properties:
     containers:
       - image: docker.io/1password/scim:v2.9.0
         name: op-scim-bridge
-        env:
-          - name: OP_REDIS_URL
-            value: "redis://localhost:6379"
-          - name: OP_SESSION
-            secretRef: scimsession
+        volumeMounts:
+          - mountPath: "/home/opuser/.op"
+            volumeName: credentials
         resources:
           cpu: 0.25
           memory: 0.5Gi
@@ -29,11 +27,17 @@ properties:
         name: op-scim-redis
         env:
           - name: REDIS_ARGS
-            value: "--maxmemory 256mb --maxmemory-policy volatile-lru"
+            value: "--maxmemory 256mb --maxmemory-policy volatile-lru --save''"
         resources:
           cpu: 0.25
           memory: 0.5Gi
     scale:
       minReplicas: 1
       maxReplicas: 1
+    volumes:
+      - name: credentials
+        storageType: Secret
+        secrets:
+        - secretRef: scimsession
+          path: scimsession
       

--- a/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml
+++ b/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml
@@ -1,0 +1,47 @@
+type: Microsoft.App/containerApps
+name: op-scim-bridge-con-app
+tags:
+  purpose: "1Password SCIM Bridge"
+properties:
+  configuration:
+    activeRevisionsMode: Single
+    ingress:
+      external: true
+      allowInsecure: false
+      targetPort: 3002
+      traffic:
+        - latestRevision: true
+          weight: 100
+      transport: Auto
+  template:
+    containers:
+      - image: docker.io/1password/scim:v2.9.0
+        name: op-scim-bridge
+        volumeMounts:
+          - mountPath: "/home/opuser/.op"
+            volumeName: credentials
+        resources:
+          cpu: 0.25
+          memory: 0.5Gi
+      - image: docker.io/redis
+        name: op-scim-redis
+        env:
+          - name: REDIS_ARGS
+            value: "--maxmemory 256mb --maxmemory-policy volatile-lru --save''"
+        resources:
+          cpu: 0.25
+          memory: 0.5Gi
+    scale:
+      minReplicas: 1
+      maxReplicas: 1
+    volumes:
+      - name: credentials
+        storageType: Secret
+        secrets:
+        - secretRef: scimsession
+          path: scimsession
+        - secretRef: workspace-settings
+          path: workspace-settings.json
+        - secretRef: workspace-creds
+          path: workspace-credentials.json      
+      


### PR DESCRIPTION
Two main aspects of this PR:

1. Alignment of using mounted secrets for all deployment paths within Azure Container Apps. 
2. Advanced and customization details to simplify the Azure Container Apps deployment for different use cases. 

The use of mounted secrets, needs to align with internal changes to our support guide for deploying on Azure Container Apps. This PR will need to be merged at the same time as the internal changes. Certain aspects of the default `azure-container-apps/aca-op-scim-bridge.yaml` align to the secret not being passed in base64, thus simplifying deployment. 

This change to the mounted secrets involves having a separate .yaml file, `azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml` to apply overtop of the existing deployment to support the Google Workspace secrets. 

Pulling the advanced configuration options out of the default README.md into a separate file allows for better external linking to sections, previously held in collapsed sections. 