### PR TITLE
added-ssl-option

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -68,7 +68,7 @@ data "aws_vpc" "this" {
 
 data "aws_subnets" "public" {
   filter {
-    name   = "vpc-id"
+    name  = "vpc-id"
     values = [data.aws_vpc.this.id]
   }
   # Find the public subnets in the VPC, or if the default VPC, use both
@@ -334,10 +334,10 @@ module "google_workspace" {
 
   source = "./modules/google-workspace"
 
-  name_prefix   = local.name_prefix
-  tags          = local.tags
-  iam_role      = aws_iam_role.op_scim_bridge
-  enabled       = local.using_google_workspace
+  name_prefix  = local.name_prefix
+  tags         = local.tags
+  iam_role     = aws_iam_role.op_scim_bridge
+  enabled      = local.using_google_workspace
   actor         = var.google_workspace_actor
   bridgeAddress = "https://${var.domain_name}"
 }

--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -68,7 +68,7 @@ data "aws_vpc" "this" {
 
 data "aws_subnets" "public" {
   filter {
-    name = "vpc-id"
+    name   = "vpc-id"
     values = [data.aws_vpc.this.id]
   }
   # Find the public subnets in the VPC, or if the default VPC, use both
@@ -265,6 +265,7 @@ resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_alb.op_scim_bridge.arn
   port              = 443
   protocol          = "HTTPS"
+  ssl_policy        = var.tls_policy
   certificate_arn = !var.wildcard_cert ? (
     var.using_route53 ?
     aws_acm_certificate_validation.op_scim_bridge[0].certificate_arn : aws_acm_certificate.op_scim_bridge[0].arn
@@ -333,10 +334,10 @@ module "google_workspace" {
 
   source = "./modules/google-workspace"
 
-  name_prefix = local.name_prefix
-  tags        = local.tags
-  iam_role    = aws_iam_role.op_scim_bridge
-  enabled     = local.using_google_workspace
+  name_prefix   = local.name_prefix
+  tags          = local.tags
+  iam_role      = aws_iam_role.op_scim_bridge
+  enabled       = local.using_google_workspace
   actor         = var.google_workspace_actor
   bridgeAddress = "https://${var.domain_name}"
 }

--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -68,7 +68,7 @@ data "aws_vpc" "this" {
 
 data "aws_subnets" "public" {
   filter {
-    name  = "vpc-id"
+    name = "vpc-id"
     values = [data.aws_vpc.this.id]
   }
   # Find the public subnets in the VPC, or if the default VPC, use both
@@ -334,10 +334,10 @@ module "google_workspace" {
 
   source = "./modules/google-workspace"
 
-  name_prefix  = local.name_prefix
-  tags         = local.tags
-  iam_role     = aws_iam_role.op_scim_bridge
-  enabled      = local.using_google_workspace
+  name_prefix = local.name_prefix
+  tags        = local.tags
+  iam_role    = aws_iam_role.op_scim_bridge
+  enabled     = local.using_google_workspace
   actor         = var.google_workspace_actor
   bridgeAddress = "https://${var.domain_name}"
 }

--- a/aws-ecsfargate-terraform/variables.tf
+++ b/aws-ecsfargate-terraform/variables.tf
@@ -46,3 +46,8 @@ variable "google_workspace_actor" {
   default     = null
   description = "The email address of the administrator in Google Workspace that the service account is acting on behalf of."
 }
+
+variable "tls_policy" {
+  type        = string
+  description = "TLS Policy to be used in for ALB HTTPS Listener"
+}


### PR DESCRIPTION
1Password SCIM example - ECS|Fargate deployment

Adding an option to add SSL policy to fix insecure TLS issue

The previous version uses old SSL Policy (ELBSecurityPolicy-2016-08)


