### PR TITLE
Remove redundant README ToCs

### DIFF
--- a/aws-ecsfargate-terraform/README.md
+++ b/aws-ecsfargate-terraform/README.md
@@ -6,15 +6,6 @@ _Learn how to deploy 1Password SCIM Bridge on AWS Fargate using Terraform._
 >
 > Due to the highly advanced and customizable nature of Amazon Web Services, this is only a suggested starting point. You can modify it to fit your existing infrastructure.
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Configure the deployment](#step-1-configure-the-deployment)
-- [Step 2: Deploy 1Password SCIM Bridge](#step-2-deploy-1password-scim-bridge)
-- [Step 3: Connect your identity provider](#step-3-connect-your-identity-provider)
-- [Update your SCIM Bridge](#update-your-scim-bridge)
-- [Troubleshooting](#troubleshooting)
-
 ## Before you begin
 
 Before you begin, complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md). You'll also need to:

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -9,14 +9,6 @@ In this guide, you can learn about advanced customizations for the Azure Contain
 - **Automatic TLS certificate management:** Azure Container Apps automatically handles TLS certificate management on your behalf.
 - **Multiple deployment options:** The SCIM bridge can be deployed directly to Azure from the Portal using [this guide](README.md) or via the Azure Shell or command line tools in your local terminal using the [support guide](https://support.1password.com/scim-deploy-azure/). If you're using a custom deployment, cloning this repository is recommended.
 
-**Table of contents:**
-
-- [Resource recommendations](#resource-recommendations)
-- [Customize your deployment](#customize-your-deployment)
-- [Update your SCIM bridge](#update-your-scim-bridge)
-- [Get help](#get-help)
-- [Appendix: If Google Workspace is your identity provider](#appendix-if-google-workspace-is-your-identity-provider)
-
 ## Resource recommendations
 
 The pod for 1Password SCIM Bridge should be vertically scaled if you provision a large number of users or groups. These are our default resource specifications and recommended configurations for provisioning at scale:

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -9,19 +9,6 @@ This deployment consists of two [containers](https://learn.microsoft.com/en-us/a
 - **Automatic TLS certificate management:** Azure Container Apps automatically handles TLS certificate management on your behalf.
 - **Multiple deployment options:** The SCIM bridge can be deployed directly to Azure from the Portal using this guide or via the Azure Shell or command line tools in your local terminal using the [support guide](https://support.1password.com/scim-deploy-azure/). If you're using a custom deployment, cloning this repository is recommended.
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Create the Container App](#step-1-create-the-container-app)
-- [Step 2: Create a secret for your `scimsession` credentials](#step-2-create-a-secret-for-your-scimsession-credentials)
-- [Step 3: Deploy the SCIM bridge container](#step-3-deploy-the-scim-bridge-container)
-- [Step 4: Enable ingress to your SCIM bridge](#step-4-enable-ingress-to-your-scim-bridge)
-- [Step 5: Test your SCIM bridge](#step-5-test-your-scim-bridge)
-- [Step 6: Connect your identity provider](#step-6-connect-your-identity-provider)
-- [Update your SCIM Bridge](#update-your-scim-bridge-in-the-azure-portal)
-- [Appendix: Resource recommendations](#appendix-resource-recommendations)
-- [Get help](#get-help)
-
 ## Before you begin
 
 Before you begin, complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md). You'll also need an Azure account with permission to create a Container App.

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -2,20 +2,6 @@
 
 This example describes how to deploy 1Password SCIM Bridge as a [stack](https://docs.docker.com/engine/swarm/stack-deploy/) using [Docker Swarm](https://docs.docker.com/engine/swarm/key-concepts/#what-is-a-swarm). The stack includes two [services](https://docs.docker.com/engine/swarm/how-swarm-mode-works/services/) (one each for the SCIM bridge container and the required Redis cache), a [Docker secret](https://docs.docker.com/engine/swarm/secrets/) for the `scimsession` credentials, a [Docker config](https://docs.docker.com/engine/swarm/configs/) for configuring Redis, and optional secrets and configuration required only for customers integrating with Google Workspace.
 
-**Table of contents:**
-
-- [In this folder](#in-this-folder)
-- [Overview](#overview)
-- [Prerequisites](#prerequisites)
-- [Get started](#get-started)
-- [Deploy 1Password SCIM bridge](#deploy-1password-scim-bridge)
-- [Test your SCIM bridge](#test-your-scim-bridge)
-- [Connect your identity provider](#connect-your-identity-provider)
-- [Update 1Password SCIM Bridge](#update-1password-scim-bridge)
-- [Rotate credentials](#rotate-credentials)
-- [Appendix: Resource recommendations](#appendix-resource-recommendations)
-- [Appendix: Customize your SCIM bridge](#appendix-customize-your-scim-bridge)
-
 ## In this folder
 
 - [`README.md`](./README.md): the document that you are reading. 👋😃

--- a/beta/google-cloud-run/README.md
+++ b/beta/google-cloud-run/README.md
@@ -6,16 +6,6 @@ This guide can be used to deploy 1Password SCIM Bridge as an ingress container f
   
 The included [Cloud Run service YAML](https://cloud.google.com/run/docs/reference/yaml/v1#service) manifests are suitable for use in a production environment without modification, but are intentionally minimal for simplicity, to allow any identity provider to connect to its public endpoint, and to facilitate its use as a base for a customized deployment.
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Set up Google Cloud](#step-1-set-up-google-cloud)
-- [Step 2: Create a secret for your `scimsession` credentials](#step-2-create-a-secret-for-your-scimsession-credentials)
-- [Step 3: Deploy your SCIM bridge](#step-3-deploy-your-scim-bridge)
-- [Step 4: Test your SCIM bridge](#step-4-test-your-scim-bridge)
-- [Step 5: Connect your identity provider](#step-5-connect-your-identity-provider)
-- [Appendix: Update your SCIM Bridge](#update-your-scim-bridge)
-
 ## Before you begin
 
 Complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md). You'll also need a Google Cloud account with permissions to create a project, set up billing, and enable Google Cloud APIs to create and manage secrets in Secret Manager.

--- a/beta/google-cloud-run/google-workspace/README.md
+++ b/beta/google-cloud-run/google-workspace/README.md
@@ -4,15 +4,6 @@ _Learn how to configure your 1Password SCIM Bridge deployed on [Cloud Run](https
 
 This directory includes [a template JSON file](./workspace-settings.json) used to configure the connection to Workspace and [a Cloud Run YAML](./op-scim-bridge-gw.yaml) that includes the additional configuration required by Cloud Run.
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Create a secret for Workspace credentials](#step-1-create-a-secret-for-workspace-credentials)
-- [Step 2: Download and edit the Workspace settings template](#step-2-download-and-edit-the-workspace-settings-template)
-- [Step 3: Create a secret for Workspace setting](#step-3-create-a-secret-for-workspace-settings)
-- [Step 4: Redeploy your SCIM Bridge to connect to Workspace](#step-4-redeploy-your-scim-bridge-to-connect-to-workspace)
-- [Appendix: Update your SCIM Bridge when Google Workspace is your IdP](#update-your-scim-bridge-when-google-workspace-is-your-idp)
-
 ## Before you begin
 
 > [!IMPORTANT]

--- a/beta/kustomize/README.md
+++ b/beta/kustomize/README.md
@@ -6,18 +6,6 @@ _Learn how to deploy 1Password SCIM Bridge on a Kubernetes cluster using Kustomi
 >
 > If you use Azure Kubernetes Service, learn how to [deploy the SCIM bridge there](https://support.1password.com/scim-deploy-azure/).
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Prepare your scimsession file](#step-1-prepare-your-scimsession-file)
-- [Step 2: Determine which overlays to use](#step-2-determine-which-overlays-to-use)
-- [Step 3: Configure the overlays (optional)](#step-3-optional-configure-the-overlays)
-- [Step 4: Prepare the deployment](#step-4-prepare-the-deployment)
-- [Step 5: Final configuration](#step-5-final-configuration)
-- [Step 6: Connect your identity provider](#step-6-connect-your-identity-provider)
-- [Update your SCIM Bridge](#update-your-scim-bridge)
-- [Appendix: Resource recommendations](#appendix-resource-recommendations)
-
 ## Before you begin
 
 Before you begin, familiarize yourself with [PREPARATION.md](/PREPARATION.md) and complete the necessary steps there.

--- a/do-app-platform-op-cli/README.md
+++ b/do-app-platform-op-cli/README.md
@@ -9,18 +9,6 @@ This deployment consists of two [resources](https://docs.digitalocean.com/glossa
 - **Automatic TLS certificate management:** App Platform automatically handles TLS certificate management on your behalf.
 - **Multiple deployment options:** You can deploy the SCIM bridge directly to DigitalOcean from your local terminal using this guide, or from the DigitalOcean Apps portal using the [support guide](https://support.1password.com/cs/scim-deploy-digitalocean-ap/). If you're using a custom deployment, cloning this repository is recommended.
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Set up your command-line tools ](#step-1-set-up-your-command-line-tools)
-- [Step 2: Generate and configure 1Password credentials](#step-2-generate-and-configure-1password-credentials)
-- [Step 3: Deploy your SCIM bridge](#step-3-deploy-your-scim-bridge)
-- [Step 4: Test your SCIM bridge](#step-4-test-your-scim-bridge)
-- [Step 5: Connect your identity provider](#step-5-connect-your-identity-provider)
-- [Update your SCIM Bridge](#update-your-scim-bridge)
-- [Appendix: Resource recommendations](#appendix-resource-recommendations)
-- [Get help](#get-help)
-
 ## Before you begin
 
 Before you begin, complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md). You'll also need:

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,19 +2,6 @@
 
 *Learn how to deploy 1Password SCIM Bridge using Docker Compose or Docker Swarm.*
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Choose a deployment option](#step-1-choose-a-deployment-option)
-- [Step 2: Install Docker tools](#step-2-install-docker-tools)
-- [Step 3: Deploy 1Password SCIM Bridge](#step-3-deploy-1password-scim-bridge)
-- [Step 4: Test the SCIM bridge](#step-4-test-the-scim-bridge)
-- [Step 5: Connect your identity provider](#step-5-connect-your-identity-provider)
-- [Update your SCIM bridge](#update-your-scim-bridge)
-- [Advanced: Manual SCIM bridge deployment](#Advanced-Manual-deployment)
-- [Appendix: Advanced `scim.env` options](#appendix-advanced-scimenv-options)
-- [Appendix: Generate `scim.env` on Windows](#appendix-generate-scimenv-on-windows)
-
 ## Before you begin
 
 Before you begin, complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md).

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -6,19 +6,6 @@ _Learn how to deploy 1Password SCIM Bridge on a Kubernetes cluster._
 >
 > If you use Azure Kubernetes Service, learn how to [deploy the SCIM bridge there](https://support.1password.com/scim-deploy-azure/).
 
-**Table of contents:**
-
-- [Before you begin](#before-you-begin)
-- [Step 1: Create the `scimsession` Kubenetes Secret](#step-1-create-the-scimsession-kubernetes-secret)
-- [Step 2: Deploy 1Password SCIM Bridge to the Kubernetes cluster](#step-2-deploy-1password-scim-bridge-to-the-kubernetes-cluster)
-- [Step 3: Create a DNS record](#step-3-create-a-dns-record)
-- [Step 4: Configure Let's Encrypt](#step-4-configure-lets-encrypt)
-- [Step 5: Test the SCIM bridge](#step-5-test-your-scim-bridge)
-- [Step 6: Connect your identity provider](#step-6-connect-your-identity-provider)
-- [Update your SCIM Bridge](#update-your-scim-bridge)
-- [Appendix: Resource recommendations](#appendix-resource-recommendations)
-- [Appendix: Customize your deployment](#appendix-customize-your-deployment)
-
 ## Before you begin
 
 Before you begin, complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md). Then clone this repository and switch to this working directory:


### PR DESCRIPTION
Since [GitHub auto-generates a table of contents](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#auto-generated-table-of-contents-for-readme-files) for READMEs (and all Markdown files), the manually coded tables are redundant.

This change cuts down on burden and maintenance of creating and updating our documents, and reduces the length of each.