### PR TITLE
Revise testing instructions

### DIFF
--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -250,14 +250,12 @@ Replace your `scimsession` secret using the Azure Cloud Shell or AZ CLI
             --secrets scimsession="$(Get-Content $HOME/scimsession)"
         ```
 
-3. Copy and paste the following command, which will have the `op-scim-bridge` container read the new secret. Replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, then run the command.
-    ```bash
-    az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --query properties.latestRevisionName
-    ```
+3. Copy and paste the following, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, then run the command to restart the `op-scim-bridge` container and read the new secret value:
 
-    Update the revsion name to use the output of the above command
-    ```
-    az containerapp revision restart -n $ConAppName -g $ResourceGroup --revision revisionName
+    ```sh
+    az containerapp revision restart -n $ConAppName -g $ResourceGroup --revision $(
+        az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --query properties.latestRevisionName
+    )
     ```
 
 4. Enter your SCIM Bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM Bridge](./README.md#step-5-test-your-scim-bridge).

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -261,7 +261,7 @@ Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ C
     az containerapp revision restart -n $ConAppName -g $ResourceGroup --revision revisionName
     ```
 
-4. Open your SCIM bridge URL in a browser and enter your bearer token to test the bridge.
+4. Enter your SCIM Bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM Bridge](./README.md#step-5-test-your-scim-bridge).
 
 5. Update your identity provider configuration with the new bearer token.
 

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -250,7 +250,7 @@ Replace your `scimsession` secret using the Azure Cloud Shell or AZ CLI
             --secrets scimsession="$(Get-Content $HOME/scimsession)"
         ```
 
-3. Copy and paste the following, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, then run the command to restart the `op-scim-bridge` container and read the new secret value:
+3. Copy and paste the following, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, then run the command to restart the `op-scim-bridge` container and read the new secret value.
 
     ```sh
     az containerapp revision restart -n $ConAppName -g $ResourceGroup --revision $(
@@ -258,7 +258,7 @@ Replace your `scimsession` secret using the Azure Cloud Shell or AZ CLI
     )
     ```
 
-4. Enter your SCIM Bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM Bridge](./README.md#step-5-test-your-scim-bridge).
+4. Enter your SCIM bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM bridge](./README.md#step-5-test-your-scim-bridge).
 
 5. Update your identity provider configuration with the new bearer token.
 

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -223,15 +223,14 @@ To view logs for your container app, click **Log Stream** on your environment or
 
 After you download a new `scimsession` file, follow the steps below to replace the secret in your Container App.
 
-Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ CLI
+Replace your `scimsession` secret using the Azure Cloud Shell or AZ CLI
 
-> The following steps assume you have moved to mounting your secret from a volume mount and not using the base64 value in your secrets. 
+> The following steps assume you have moved to mounting your secret from a volume mount and not using the base64 value in your secrets.
 > Follow the [command to update your deployment with the updated YAML file](https://support.1password.com/scim-deploy-azure/#step-3-set-up-and-deploy-1password-scim-bridge) to use volume mounts, redefining your variables as needed for this command to succeed. 
-
 
 1. Open the [Azure Shell](https://shell.azure.com) or use the `az` CLI tool.
 
-2. Copy and paste the following command, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, and run the command.
+2. Copy and paste the following, replace `$ConAppName` and `$ResourceGroup` with the names from your deployment, then run the command:
 
     - **Bash**:
 
@@ -283,13 +282,17 @@ To connect Google Workspace using the Azure Portal interface, you can follow the
 
 1. Run the following command for your shell to get the `./google-workspace/workspace-settings.json` file.
     - **Bash**:
-    ```bash
-    curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/azure-container-apps/google-workspace/workspace-settings.json --output workspace-settings.json --silent
-    ```
+
+        ```bash
+        curl https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/azure-container-apps/google-workspace/workspace-settings.json --output workspace-settings.json --silent
+        ```
+
     - **PowerShell**:
-    ```pwsh
-    Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/azure-container-apps/google-workspace/workspace-settings.json -OutFile workspace-settings.json
-    ```
+
+        ```pwsh
+        Invoke-RestMethod -Uri `https://raw.githubusercontent.com/1Password/scim-examples/solutions/main/azure-container-apps/google-workspace/workspace-settings.json -OutFile workspace-settings.json
+        ```
+
 2. Edit the following in the .json file:
     - **Actor**: Enter the email address of the Google Workspace administrator for the service account.
     - **Bridge Address**: Enter your SCIM bridge domain. This is the Application URL for your Container App, found on the overview page (not your 1Password account sign-in address). For example: `https://scim.example.com`. Ensure to leave the `https://` in the bridge address, and do not add any trailing `/` to your URL.

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -183,7 +183,8 @@ If you're provisioning more than 1,000 users, update the resources assigned to [
 
 To use a new `scimsession` credentials file for your SCIM bridge, replace the secret in your Container App:
 
-Replace your `scimsession` secret using the Azure Portal
+<details>
+<summary>Replace your `scimsession` secret using the Azure Portal</summary>
 
 1. Open the Azure Portal and go to the [Container Apps](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps) page.
 2. Choose **Secrets** from the Settings section in the sidebar.
@@ -192,6 +193,7 @@ Replace your `scimsession` secret using the Azure Portal
 5. Choose the **Revisions** from the Application section in the sidebar.
 6. Click your current active revision and choose **Restart** in the details pane.
 7. Enter your SCIM bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM bridge](#step-5-test-your-scim-bridge).
+</details>
 8. Update your identity provider configuration with the new bearer token.
 
 <details>

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -83,7 +83,7 @@ After the deployment is complete, click **Go to resource**, then continue to ste
 
 ## Step 5: Test your SCIM bridge
 
-To test if your SCIM bridge is online, choose **Overview** in your application's sidebar, then click your **Application Url** link. This URL is your SCIM bridge domain. You should be able to enter your bearer token to verify that your SCIM bridge is up and running.
+To test if your SCIM bridge is online, choose **Overview** in your application's sidebar, then click your **Application Url** link. Thi is your **SCIM Bridge URL**. Sign in using your bearer token to verify that your SCIM Bridge is connected to your 1Password account.
 
 ## Step 6: Connect your identity provider
 
@@ -191,7 +191,7 @@ Replace your <code>scimsession</code> secret using the Azure Portal
 4. Select the checkbox and click **Save**.
 5. Choose the **Revisions** from the Application section in the sidebar.
 6. Click your current active revision and choose **Restart** in the details pane.
-7. Open your SCIM bridge URL in a browser and enter you new bearer token to test the bridge.
+7. Enter your SCIM Bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM Bridge](#step-5-test-your-scim-bridge).
 8. Update your identity provider configuration with the new bearer token.
 
 <details>

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -181,9 +181,9 @@ If you're provisioning more than 1,000 users, update the resources assigned to [
 
 ### How to update the **scimsession** secret
 
-After you download a new `scimsession` file, follow the steps below to replace the secret in your Container App.
+To use a new `scimsession` credentials file for your SCIM Bridge, follow replace the secret in your Container App:
 
-Replace your <code>scimsession</code> secret using the Azure Portal
+Replace your `scimsession` secret using the Azure Portal
 
 1. Open the Azure Portal and go to the [Container Apps](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps) page.
 2. Choose **Secrets** from the Settings section in the sidebar.

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -193,8 +193,8 @@ To use a new `scimsession` credentials file for your SCIM bridge, replace the se
 5. Choose the **Revisions** from the Application section in the sidebar.
 6. Click your current active revision and choose **Restart** in the details pane.
 7. Enter your SCIM bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM bridge](#step-5-test-your-scim-bridge).
-</details>
 8. Update your identity provider configuration with the new bearer token.
+</details>
 
 <details>
 <summary>Replace your <code>scimsession</code> secret using the Azure Cloud Shell or AZ CLI</summary>

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -83,7 +83,7 @@ After the deployment is complete, click **Go to resource**, then continue to ste
 
 ## Step 5: Test your SCIM bridge
 
-To test if your SCIM bridge is online, choose **Overview** in your application's sidebar, then click your **Application Url** link. Thi is your **SCIM Bridge URL**. Sign in using your bearer token to verify that your SCIM Bridge is connected to your 1Password account.
+To test if your SCIM bridge is online, choose **Overview** in your application's sidebar, then click your **Application Url** link. This is your **SCIM bridge URL**. Sign in using your bearer token to verify that your SCIM bridge is connected to your 1Password account.
 
 ## Step 6: Connect your identity provider
 
@@ -181,7 +181,7 @@ If you're provisioning more than 1,000 users, update the resources assigned to [
 
 ### How to update the **scimsession** secret
 
-To use a new `scimsession` credentials file for your SCIM Bridge, follow replace the secret in your Container App:
+To use a new `scimsession` credentials file for your SCIM bridge, replace the secret in your Container App:
 
 Replace your `scimsession` secret using the Azure Portal
 
@@ -191,7 +191,7 @@ Replace your `scimsession` secret using the Azure Portal
 4. Select the checkbox and click **Save**.
 5. Choose the **Revisions** from the Application section in the sidebar.
 6. Click your current active revision and choose **Restart** in the details pane.
-7. Enter your SCIM Bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM Bridge](#step-5-test-your-scim-bridge).
+7. Enter your SCIM bridge URL in another browser tab or window and sign in using your new bearer token to [test your SCIM bridge](#step-5-test-your-scim-bridge).
 8. Update your identity provider configuration with the new bearer token.
 
 <details>

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -174,7 +174,7 @@ docker stack config \
 
 ## Test your SCIM bridge
 
-Run this command to view logs from the service for the SCIM Bridge container:
+Run this command to view logs from the service for the SCIM bridge container:
 
 ```sh
 docker service logs op-scim-bridge_scim --raw
@@ -228,7 +228,7 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
 </details>
 <br />
 
-Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
+To view this information in a visual format, visit your SCIM bridge URL in a web browser. Sign in with your bearer token, then you can view status information and download container log files.
 
 ## Connect your identity provider
 

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -174,81 +174,61 @@ docker stack config \
 
 ## Test your SCIM bridge
 
-Run this command to retrieve logs from the service for the SCIM bridge container:
+Run this command to view logs from the service for the SCIM Bridge container:
 
 ```sh
 docker service logs op-scim-bridge_scim --raw
 ```
 
-Your SCIM bridge URL is based on the fully qualified domain name of the DNS record created in [Get started](#get-started), for example `https://scim.example.com/`. You can access your SCIM bridge in a web browser at this URL by signing in using your bearer token.
-
-You can also test your SCIM bridge by sending an authenticated SCIM API request.
-
-_Example command:_
+Your **SCIM Bridge URL** is based on the fully qualified domain name of the DNS record created in [Get started](#get-started), for example `https://scim.example.com`. Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM Bridge URL to test the connection and view status information.
 
 ```sh
-curl --header "Authorization: Bearer mF_9.B5f-4.1JqM" https://scim.example.com/Users
+curl --silent --show-error --request GET --header "Accept: application/json" \
+  --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
+  https:/scim.example.com/health
 ```
 
-Copy the example command to a text editor. Replace `mF_9.B5f-4.1JqM` with your bearer token and `scim.example.com` with the fully qualified domain name of the DNS record created in [Get started](#get-started) before running the command in your terminal.
-
-> **Note**
->
-> 💻 If you saved your bearer token as an item in your 1Password account, you can [use 1Password CLI to securely pass the
-> bearer token](https://developer.1password.com/docs/cli/secrets-scripts#option-2-use-op-read-to-read-secrets)
-> instead of writing it out in the console. For example: `--header "Authorization: Bearer $(op read
-"op://Private/bearer token/credential")"`
-
 <details>
-<summary>Example JSON response</summary>
+<summary>Example JSON response:</summary>
 
-> ```json
-> {
->   "Resources": [
->     {
->       "active": true,
->       "displayName": "Eggs Ample",
->       "emails": [
->         {
->           "primary": true,
->           "type": "",
->           "value": "eggs.ample@example.com"
->         }
->       ],
->       "externalId": "",
->       "groups": [
->         {
->           "value": "f7eqriu7ht27mq5zmm63gf2dhq",
->           "ref": "https://scim.example.com/Groups/f7eqriu7ht27mq5zmm63gf2dhq"
->         }
->       ],
->       "id": "FECPUMYBHZB2PB6K4WKM4Q2HAU",
->       "meta": {
->         "created": "",
->         "lastModified": "",
->         "location": "",
->         "resourceType": "User",
->         "version": ""
->       },
->       "name": {
->         "familyName": "Ample",
->         "formatted": "Eggs Ample",
->         "givenName": "Eggs",
->         "honorificPrefix": "",
->         "honorificSuffix": "",
->         "middleName": ""
->       },
->       "schemas": [
->         "urn:ietf:params:scim:schemas:core:2.0:User"
->       ],
->       "userName": "eggs.ample@example.com"
->     },
->     ...
->   ]
-> }
-> ```
+```json
+{
+  "build": "209031",
+  "version": "2.9.3",
+  "reports": [
+    {
+      "source": "ConfirmationWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "RedisCache",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "SCIMServer",
+      "time": "2024-04-25T14:06:56Z",
+      "expires": "2024-04-25T14:16:56Z",
+      "state": "healthy"
+    },
+    {
+      "source": "StartProvisionWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    }
+  ],
+  "retrievedAt": "2024-04-25T14:06:56Z"
+}
+```
 
 </details>
+<br />
+
+Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
 
 ## Connect your identity provider
 

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -180,7 +180,7 @@ Run this command to view logs from the service for the SCIM bridge container:
 docker service logs op-scim-bridge_scim --raw
 ```
 
-Your **SCIM Bridge URL** is based on the fully qualified domain name of the DNS record created in [Get started](#get-started), for example `https://scim.example.com`. Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM Bridge URL to test the connection and view status information.
+Your **SCIM bridge URL** is based on the fully qualified domain name of the DNS record created in [Get started](#get-started). For example: `https://scim.example.com`. Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM bridge URL to test the connection and view status information.
 
 ```sh
 curl --silent --show-error --request GET --header "Accept: application/json" \

--- a/beta/docker/README.md
+++ b/beta/docker/README.md
@@ -234,7 +234,6 @@ Similar information is presented graphically by accessing your SCIM Bridge URL i
 
 Use your SCIM bridge URL and bearer token to [connect your identity provider to 1Password SCIM Bridge](https://support.1password.com/scim/#step-3-connect-your-identity-provider).
 
-
 ## Update 1Password SCIM Bridge
 
 Swarm mode in Docker Engine uses a declarative service model. Services will automatically restart tasks when updating their configuration.

--- a/do-app-platform-op-cli/README.md
+++ b/do-app-platform-op-cli/README.md
@@ -83,9 +83,9 @@ Invoke-RestMethod -Uri https://raw.githubusercontent.com/1Password/scim-examples
 
 ## Step 4: Test your SCIM bridge
 
-After you deploy your SCIM bridge, you'll see a URL in the `Default Ingress` column of the terminal output. This is your **SCIM Bridge URL**. Run the following command for your shell to test the connection to 1Password.
+After you deploy your SCIM bridge, you'll see a URL in the `Default Ingress` column of the terminal output. This is your **SCIM bridge URL**. Run the following command for your shell to test the connection to 1Password.
 
-Copy the following, replace `https://op-scim-bridge-example.ondigitalocean.app` with your SCIM Bridge URL, then run the command in your terminal to test the connection and view status information:
+Copy the following command, replace `https://op-scim-bridge-example.ondigitalocean.app` with your SCIM bridge URL, then run the command in your terminal to test the connection and view status information.
 
 **Bash**:
 
@@ -143,7 +143,7 @@ Invoke-RestMethod -Method GET -Auth OAuth -Token $(
 </details>
 <br />
 
-Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
+To view this information in a visual format, visit your SCIM bridge URL in a web browser. Sign in with your bearer token, then you can view status information and download container log files.
 
 ## Step 5: Connect your identity provider
 

--- a/do-app-platform-op-cli/README.md
+++ b/do-app-platform-op-cli/README.md
@@ -83,21 +83,67 @@ Invoke-RestMethod -Uri https://raw.githubusercontent.com/1Password/scim-examples
 
 ## Step 4: Test your SCIM bridge
 
-After you deploy your SCIM bridge, you'll see a URL in the `Default Ingress` column of the terminal output. This URL is your SCIM bridge domain. Run the following command for your shell to test the connection to 1Password.
+After you deploy your SCIM bridge, you'll see a URL in the `Default Ingress` column of the terminal output. This is your **SCIM Bridge URL**. Run the following command for your shell to test the connection to 1Password.
+
+Copy the following, replace `https://op-scim-bridge-example.ondigitalocean.app` with your SCIM Bridge URL, then run the command in your terminal to test the connection and view status information:
 
 **Bash**:
 
-```sh
-curl --header "Authorization: Bearer $(op read op://${VAULT:-op-scim}/${ITEM:-"bearer token"}/credential)" https://op-scim-bridge-example.ondigitalocean.app/Users
+```bash
+curl --silent --show-error --request GET --header "Accept: application/json" --header "Authorization: Bearer $(
+  op read op://${VAULT:-op-scim}/${ITEM:-"bearer token"}/credential)"
+) https://op-scim-bridge-example.ondigitalocean.app/health
 ```
 
-**Powershell**:
+**PowerShell**:
 
 ```pwsh
-Invoke-WebRequest -Method Get -Uri 'https://op-scim-bridge-example.ondigitalocean.app/Users' -Headers @{'Authorization' ="Bearer $(op read "op://op-scim/bearer token/credential")"}
+Invoke-RestMethod -Method GET -Auth OAuth -Token $(
+    op read "op://op-scim/bearer token/credential" | ConvertTo-SecureString -AsPlainText
+) -Uri https://op-scim-bridge-example.ondigitalocean.app/health | ConvertTo-Json
 ```
 
-You can also access your SCIM bridge by visiting the SCIM bridge domain in your web browser and entering the bearer token from your 1Password item.
+<details>
+<summary>Example JSON response:</summary>
+
+```json
+{
+  "build": "209031",
+  "version": "2.9.3",
+  "reports": [
+    {
+      "source": "ConfirmationWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "RedisCache",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "SCIMServer",
+      "time": "2024-04-25T14:06:56Z",
+      "expires": "2024-04-25T14:16:56Z",
+      "state": "healthy"
+    },
+    {
+      "source": "StartProvisionWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    }
+  ],
+  "retrievedAt": "2024-04-25T14:06:56Z"
+}
+```
+
+</details>
+<br />
+
+Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
 
 ## Step 5: Connect your identity provider
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -113,6 +113,7 @@ Alternate Google Workspace stack deployment command:
 # deploy your Stack with Google Workspace settings
 docker stack deploy -c docker-compose.yml -c gw-docker-compose.yml op-scim
 ```
+
 Learn more about [connecting Google Workspace to 1Password SCIM Bridge](https://support.1password.com/scim-google-workspace/).
 
 ### Self managed TLS for Docker Swarm

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,7 +40,7 @@ The logs from the SCIM bridge and Redis containers will be streamed to your mach
 At this point, you should set a DNS record routing the domain name to the IP address of the `op-scim` container.
 
 > [!IMPORTANT]
-> This domain name of this DNS record is used for your **SCIM Bridge URL**. For example, if the record name is `op-scim-bridge.example.com`, then your SCIM Bridge URL is `https://op-scim-bridge.example.com`.
+> The DNS record name is used for your **SCIM bridge URL**. For example, if the record name is `op-scim-bridge.example.com`, then your SCIM bridge URL is `https://op-scim-bridge.example.com`.
 
 ### Docker Compose
 
@@ -163,7 +163,7 @@ It is not recommended to use Docker Compose for your SCIM bridge deployment if y
 
 ## Step 4: Test the SCIM bridge
 
-Use your SCIM Bridge URL to test the connection and view status information. For example:
+Use your SCIM bridge URL to test the connection and view status information. For example:
 
 ```sh
 curl --silent --show-error --request GET --header "Accept: application/json" \
@@ -171,7 +171,7 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
   https://op-scim-bridge.example.com/health
 ```
 
-Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://op-scim-bridge.example.com` with your SCIM Bridge URL.
+Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://op-scim-bridge.example.com` with your SCIM bridge URL.
 
 <details>
 <summary>Example JSON response:</summary>
@@ -213,7 +213,7 @@ Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://op-scim-bridge.exa
 </details>
 <br />
 
-Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
+To view this information in a visual format, visit your SCIM bridge URL in a web browser. Sign in with your bearer token, then you can view status information and download container log files.
 
 ## Step 5: Connect your identity provider
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,6 +39,9 @@ The logs from the SCIM bridge and Redis containers will be streamed to your mach
 
 At this point, you should set a DNS record routing the domain name to the IP address of the `op-scim` container.
 
+> [!IMPORTANT]
+> This domain name of this DNS record is used for your **SCIM Bridge URL**. For example, if the record name is `op-scim-bridge.example.com`, then your SCIM Bridge URL is `https://op-scim-bridge.example.com`.
+
 ### Docker Compose
 
 To deploy with Docker Compose, you'll need Docker Desktop set up either locally or remotely. Learn how to [set up Docker Desktop](https://docs.docker.com/desktop/). Then follow these steps:
@@ -159,13 +162,57 @@ It is not recommended to use Docker Compose for your SCIM bridge deployment if y
 
 ## Step 4: Test the SCIM bridge
 
-To test if your SCIM bridge is online, open the public IP address of the Docker Host for your bridge in a web browser. You should be able to enter your bearer token to verify that your SCIM bridge is up and running.
+Use your SCIM Bridge URL to test the connection and view status information. For example:
 
-You can also use the following `curl` command to test the SCIM bridge from the command line:
-
-```bash
-curl --header "Authorization: Bearer TOKEN_GOES_HERE" https://<domain>/scim/Users
+```sh
+curl --silent --show-error --request GET --header "Accept: application/json" \
+  --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
+  https://op-scim-bridge.example.com/health
 ```
+
+Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://op-scim-bridge.example.com` with your SCIM Bridge URL.
+
+<details>
+<summary>Example JSON response:</summary>
+
+```json
+{
+  "build": "209031",
+  "version": "2.9.3",
+  "reports": [
+    {
+      "source": "ConfirmationWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "RedisCache",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "SCIMServer",
+      "time": "2024-04-25T14:06:56Z",
+      "expires": "2024-04-25T14:16:56Z",
+      "state": "healthy"
+    },
+    {
+      "source": "StartProvisionWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    }
+  ],
+  "retrievedAt": "2024-04-25T14:06:56Z"
+}
+```
+
+</details>
+<br />
+
+Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
 
 ## Step 5: Connect your identity provider
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -177,10 +177,10 @@ If you regenenerate credentials for your SCIM bridge:
 1. Download the new `scimsession` file from your 1Password account.
 2. Delete the `scimsession` Secret on your cluster and recreate it from the new file:
 
-   ```sh
-   kubectl delete secret scimsession
-   kubectl create secret generic scimsession --from-file=scimsession=./scimsession
-   ```
+    ```sh
+    kubectl delete secret scimsession
+    kubectl create secret generic scimsession --from-file=scimsession=./scimsession
+    ```
 
    Kubernetes automatically updates the credentials file mounted in the Pod with the new Secret value.
 3. [Test your SCIM bridge](#step-5-test-your-scim-bridge) using the new bearer token associated with the regenerated `scimsession` file.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -96,70 +96,59 @@ kubectl set env deploy/op-scim-bridge OP_TLS_DOMAIN=scim.example.com
 
 Replace `scim.example.com` with the fully qualified domain name of the DNS record before running this command. Your SCIM bridge will restart, request a TLS certificate from Let's Encrypt, and automatically renew the certificate on your behalf.
 
-## Step 5: Test your SCIM bridge
+## Step 5: Test your SCIM Bridge
 
-You can test the connection to your SCIM bridge and view status and logs in a web browser at the URL based on its fully qualified domain name (for example `https://scim.example.com/`). Sign in to your SCIM bridge using the bearer token associated with the `scimsession` credentials stored as a Secret on your cluster.
-
-You can also test your SCIM bridge by sending an authenticated SCIM API request.
-
-_Example command:_
+Use your SCIM Bridge URL to test the connection and view status information. For example:
 
 ```sh
-curl --header "Authorization: Bearer mF_9.B5f-4.1JqM" https://scim.example.com/Users
+curl --silent --show-error --request GET --header "Accept: application/json" \
+  --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
+  https:/scim.example.com/health
 ```
 
-Copy the example command to a text editor. Replace `mF_9.B5f-4.1JqM` with your bearer token and `scim.example.com` with its fully qualified domain name.
+Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM Bridge URL.
 
 <details>
-<summary>Example JSON response</summary>
+<summary>Example JSON response:</summary>
 
-> ```json
-> {
->   "Resources": [
->     {
->       "active": true,
->       "displayName": "Eggs Ample",
->       "emails": [
->         {
->           "primary": true,
->           "type": "",
->           "value": "eggs.ample@example.com"
->         }
->       ],
->       "externalId": "",
->       "groups": [
->         {
->           "value": "f7eqriu7ht27mq5zmm63gf2dhq",
->           "ref": "https://scim.example.com/Groups/f7eqriu7ht27mq5zmm63gf2dhq"
->         }
->       ],
->       "id": "FECPUMYBHZB2PB6K4WKM4Q2HAU",
->       "meta": {
->         "created": "",
->         "lastModified": "",
->         "location": "",
->         "resourceType": "User",
->         "version": ""
->       },
->       "name": {
->         "familyName": "Ample",
->         "formatted": "Eggs Ample",
->         "givenName": "Eggs",
->         "honorificPrefix": "",
->         "honorificSuffix": "",
->         "middleName": ""
->       },
->       "schemas": [
->         "urn:ietf:params:scim:schemas:core:2.0:User"
->       ],
->       "userName": "eggs.ample@example.com"
->     },
->     ...
->   ]
-> }
-> ```
+```json
+{
+  "build": "209031",
+  "version": "2.9.3",
+  "reports": [
+    {
+      "source": "ConfirmationWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "RedisCache",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "SCIMServer",
+      "time": "2024-04-25T14:06:56Z",
+      "expires": "2024-04-25T14:16:56Z",
+      "state": "healthy"
+    },
+    {
+      "source": "StartProvisionWatcher",
+      "time": "2024-04-25T14:06:09Z",
+      "expires": "2024-04-25T14:16:09Z",
+      "state": "healthy"
+    }
+  ],
+  "retrievedAt": "2024-04-25T14:06:56Z"
+}
+```
 
 </details>
+<br />
+
+Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
 
 ## Step 6: Connect your identity provider
 
@@ -179,7 +168,7 @@ kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.9.4
 > [`op-scim-deployment.yaml`](./op-scim-deployment.yaml) file (and in the command above in this file) in the main
 > branch of this repository.
 
-Your SCIM bridge should automatically reboot using the specified version, typically in a few moments.
+Your SCIM Bridge should automatically reboot using the specified version, typically in a few moments.
 
 ## Rotate credentials
 
@@ -194,9 +183,8 @@ If you regenenerate credentials for your SCIM bridge:
    ```
 
    Kubernetes automatically updates the credentials file mounted in the Pod with the new Secret value.
-
-3. Test your SCIM bridge using the new bearer token associated with the regenerated `scimsession` file.
-4. Update your identity provider configuration with the new bearer token.
+3. [Test your SCIM bridge](#step-5-test-your-scim-bridge) using the new bearer token associated with the regenerated `scimsession` file.
+4. Update your identity provider configuration with your new bearer token.
 
 ## Appendix: Resource recommendations
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -96,9 +96,9 @@ kubectl set env deploy/op-scim-bridge OP_TLS_DOMAIN=scim.example.com
 
 Replace `scim.example.com` with the fully qualified domain name of the DNS record before running this command. Your SCIM bridge will restart, request a TLS certificate from Let's Encrypt, and automatically renew the certificate on your behalf.
 
-## Step 5: Test your SCIM Bridge
+## Step 5: Test your SCIM bridge
 
-Use your SCIM Bridge URL to test the connection and view status information. For example:
+Use your SCIM bridge URL to test the connection and view status information. For example:
 
 ```sh
 curl --silent --show-error --request GET --header "Accept: application/json" \
@@ -106,7 +106,7 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
   https:/scim.example.com/health
 ```
 
-Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM Bridge URL.
+Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM bridge URL.
 
 <details>
 <summary>Example JSON response:</summary>
@@ -148,7 +148,7 @@ Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` 
 </details>
 <br />
 
-Similar information is presented graphically by accessing your SCIM Bridge URL in a web browser. Sign in with your bearer token to view status information and download container log files.
+To view this information in a visual format, visit your SCIM bridge URL in a web browser. Sign in with your bearer token, then you can view status information and download container log files.
 
 ## Step 6: Connect your identity provider
 
@@ -168,7 +168,7 @@ kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.9.4
 > [`op-scim-deployment.yaml`](./op-scim-deployment.yaml) file (and in the command above in this file) in the main
 > branch of this repository.
 
-Your SCIM Bridge should automatically reboot using the specified version, typically in a few moments.
+Your SCIM bridge should automatically reboot using the specified version, typically in a few moments.
 
 ## Rotate credentials
 


### PR DESCRIPTION
This PR revises testing instructions across all deployment examples. Documentation for testing often invokes some other endpoint (e.g. `/Users`), but `/health` is designed for determining health state, and is supported when connecting all identity providers, _including_ Google Workspace.

Some bonus formatting fixes in adjacent text are also included, as well as simplified steps that can potentially be excluded from this merge; the core changes are included in https://github.com/1Password/scim-examples/commit/cc19849649ee1cc41c745f88dbfdc50a1813703d.

Resolves #257.