### PR TITLE
Update op_confirmation_interval documentation

### DIFF
--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -90,7 +90,7 @@ You can customize your 1Password SCIM Bridge deployment using some of the method
 <summary>Confirmation Interval</summary>
 
 Use the OP_CONFIRMATION_INTERVAL environment variable to set how often the ConfirmationWatcher component runs in seconds. The minimum
-interval is 30 seconds. If not set, the default value of 300 seconds (5 minutes) is used.
+interval is 5 seconds. If not set, the default value of 300 seconds (5 minutes) is used.
 
 For example set `OP_CONFIRMATION_INTERVAL` to `30` to have the ConfirmationWatcher running every 30 seconds.
 

--- a/beta/docker/scim.env
+++ b/beta/docker/scim.env
@@ -14,7 +14,7 @@ OP_TLS_DOMAIN=
 # OP_LETSENCRYPT_EMAIL=eggs.ample@example.com
 
 # Set OP_CONFIRMATION_INTERVAL to an interval in seconds for the ConfirmationWatcher component to run. This worker
-# automatically confirms users who have accepted their invitation. The minimum interval is 30 seconds. If not set, the
+# automatically confirms users who have accepted their invitation. The minimum interval is 5 seconds. If not set, the
 # default value of 300 seconds (5 minutes) is used.
 # OP_CONFIRMATION_INTERVAL=30
 

--- a/kubernetes/op-scim-config.yaml
+++ b/kubernetes/op-scim-config.yaml
@@ -65,7 +65,7 @@ data:
   # OP_PING_SERVER: "1"
 
   # Use OP_CONFIRMATION_INTERVAL to set how often the ConfirmationWatcher component runs in seconds. The minimum
-  # interval is 30 seconds. If not set, the default value of 300 seconds (5 minutes) is used.
+  # interval is 5 seconds. If not set, the default value of 300 seconds (5 minutes) is used.
   # OP_CONFIRMATION_INTERVAL: "30"
 
   # Set OP_DNS_CHALLENGE_CONFIG_FILE to the path of a valid configuration file mounted in the container filesystem to


### PR DESCRIPTION
With the recent confirmationWatcher service change in [version 2.9.4](https://releases.1password.com/provisioning/scim-bridge/#1password-scim-bridge-2.9.4), the documentation around OP_CONFIRMATION_INTERVAL was no longer accurate with regards to the minimum interval.

Small fix to update this documentation where present around the minimum value for this optional environment variable. 