### PR TITLE
change resource recommendation for memory-very high

### DIFF
--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -66,7 +66,7 @@ To update the high-volume within the Azure Portal:
 If you're provisioning more than 5,000 users, run the following command:
 
 ```bash
-az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --cpu 1.0 --memory 1.0Gi
+az containerapp update -n $ConAppName -g $ResourceGroup --container-name op-scim-bridge --cpu 1.0 --memory 2.0Gi
 ```
 
 To update the very high-volume within the Azure Portal: 

--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -17,7 +17,7 @@ The pod for 1Password SCIM Bridge should be vertically scaled if you provision a
 | --------- | --------------- | ----- | ------ |
 | Default   | <1,000          | 0.25  | 0.5Gi  |
 | High      | 1,000–5,000     | 0.5   | 1.0Gi  |
-| Very high | >5,000          | 1.0   | 1.0Gi  |
+| Very high | >5,000          | 1.0   | 2.0Gi  |
 
 If you're provisioning more than 1,000 users, update the resources assigned to the SCIM bridge container to follow these recommendations. The resources specified for the Redis container don't need to be adjusted.
 

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -173,7 +173,7 @@ The pod for 1Password SCIM Bridge should be vertically scaled if you provision a
 | --------- | --------------- | ---- | ------ |
 | Default   | <1,000          | 0.25 | 0.5Gi  |
 | High      | 1,000–5,000     | 0.5  | 1.0Gi  |
-| Very high | >5,000          | 1.0  | 1.0Gi  |
+| Very high | >5,000          | 1.0  | 2.0Gi  |
 
 If you're provisioning more than 1,000 users, update the resources assigned to [the SCIM bridge container](#22-continue-creating-the-container-app) to follow these recommendations. The resources specified for the Redis container don't need to be adjusted. Steps can be found on our [Advanced guide](ADVANCED.md) on how to update your resources.
 

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -165,18 +165,6 @@ To connect Google Workspace using the Azure Cloud Shell or AZ CLI, follow the st
 
 After you sign in to your SCIM bridge, the [Automated User Provisioning page](https://start.1password.com/integrations/active/) in your 1Password account will also update with the latest access time and SCIM bridge version.
 
-## Appendix: Resource recommendations
-
-The pod for 1Password SCIM Bridge should be vertically scaled if you provision a large number of users or groups. These are our default resource specifications and recommended configurations for provisioning at scale:
-
-| Volume    | Number of users | CPU  | memory |
-| --------- | --------------- | ---- | ------ |
-| Default   | <1,000          | 0.25 | 0.5Gi  |
-| High      | 1,000–5,000     | 0.5  | 1.0Gi  |
-| Very high | >5,000          | 1.0  | 2.0Gi  |
-
-If you're provisioning more than 1,000 users, update the resources assigned to [the SCIM bridge container](#22-continue-creating-the-container-app) to follow these recommendations. The resources specified for the Redis container don't need to be adjusted. Steps can be found on our [Advanced guide](ADVANCED.md) on how to update your resources.
-
 ## Get help
 
 > [!TIP]


### PR DESCRIPTION
Edit resource recommendation section of Azure Container Apps deployment.
For `high volume` > `memory`, it should be 2.0Gi per [this docs](https://arc.net/l/quote/zjmnltwb).