### PR TITLE
Make ECSCluster resource dependent on ExecutionRole

### DIFF
--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -156,6 +156,7 @@ Resources:
 
   ECSCluster:
     Type: "AWS::ECS::Cluster"
+    DependsOn: ExecutionRole
     Properties:
       CapacityProviders:
         - FARGATE


### PR DESCRIPTION
This PR introduces a single change to the `ECSCluster` resource to make it dependent upon the `ExecutionRole`.

Resolves #288.

To test: deploy a new stack for SCIM Bridge, test, verify correct operation.