### PR TITLE
Update aca-op-scim-bridge.yaml

### DIFF
--- a/azure-container-apps/aca-op-scim-bridge.yaml
+++ b/azure-container-apps/aca-op-scim-bridge.yaml
@@ -14,7 +14,7 @@ properties:
       transport: Auto
   template:
     containers:
-      - image: docker.io/1password/scim:v2.9.5
+      - image: docker.io/1password/scim:v2.9.7
         name: op-scim-bridge
         volumeMounts:
           - mountPath: "/home/opuser/.op"

--- a/azure-container-apps/aca-op-scim-bridge.yaml
+++ b/azure-container-apps/aca-op-scim-bridge.yaml
@@ -1,5 +1,4 @@
 type: Microsoft.App/containerApps
-name: op-scim-bridge-con-app
 tags:
   purpose: "1Password SCIM Bridge"
 properties:


### PR DESCRIPTION
When using a different naming convention for the Container App, the cli start complaining about mismatches in name. Dropping the name from the yaml config, keeps the name as used during creation.

I don't really care about the container names within the App, so left those as-is.