### PR TITLE
Fix to bash command typo in DO App Platform CLI README, in test SCIM bridge section

### DIFF
--- a/do-app-platform-op-cli/README.md
+++ b/do-app-platform-op-cli/README.md
@@ -91,8 +91,7 @@ Copy the following command, replace `https://op-scim-bridge-example.ondigitaloce
 
 ```bash
 curl --silent --show-error --request GET --header "Accept: application/json" --header "Authorization: Bearer $(
-  op read op://${VAULT:-op-scim}/${ITEM:-"bearer token"}/credential)"
-) https://op-scim-bridge-example.ondigitalocean.app/health
+  op read op://${VAULT:-op-scim}/${ITEM:-"bearer token"}/credential)" https://op-scim-bridge-example.ondigitalocean.app/health
 ```
 
 **PowerShell**:


### PR DESCRIPTION
Noticed the do-app-platform-op-cli README has a small typo in "Step 4: Test your SCIM bridge.... [Bash](https://github.com/1Password/scim-examples/tree/main/do-app-platform-op-cli#:~:text=view%20status%20information.-,Bash%3A,-curl%20%2D%2Dsilent%20%2D%2Dshow)". In the Bash command used to test the connection and view status info there is an un-used `)` after `"bearer token"}/credential)"` that causes the following error when running that command: ```parse error near `)'```.

Full command:
```
curl --silent --show-error --request GET --header "Accept: application/json" --header "Authorization: Bearer $(
  op read op://${VAULT:-op-scim}/${ITEM:-"bearer token"}/credential)"
) https://op-scim-bridge-example.ondigitalocean.app/health
```

Small change just to remove that `)`, confirmed working in testing and expected JSON is returned.