### PR TITLE
Small resource spec fix for ACA very high volume deployment within the Azure portal steps

### DIFF
--- a/azure-container-apps/ADVANCED.md
+++ b/azure-container-apps/ADVANCED.md
@@ -74,7 +74,7 @@ To update the very high-volume within the Azure Portal:
 1. Within Container App from the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
 2. Click **Edit and deploy**.
 3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
-4. Set the **CPU cores** to `1.0` and the **Memory (Gi)** to `1.0`.
+4. Set the **CPU cores** to `1.0` and the **Memory (Gi)** to `2.0`.
 5. Click **Save**, then click **Create**.
 </details>
 


### PR DESCRIPTION
Small fix to align the very high volume resource specs steps for making changes in the Azure GUI portal to match the az commands shown in the Advanced.md. 

These specs were recently updated in [PR314](https://github.com/1Password/scim-examples/pull/314), however the very high volume written steps within the Azure Portal were missed in the previous PR. 

Memory should be spec'd at 2.0Gi. 