### PR TITLE
Use new minimal App Platform pricing slug

### DIFF
--- a/do-app-platform-op-cli/README.md
+++ b/do-app-platform-op-cli/README.md
@@ -268,13 +268,13 @@ Invoke-RestMethod -Uri https://raw.githubusercontent.com/1Password/scim-examples
 If you're provisioning more than 1,000 users:
 
 1. Download the [`op-scim-bridge.yaml`](/do-app-platform-op-cli/op-scim-bridge.yaml) file and open it in a text editor.
-2. Change the `instance_size_slug` value for the `op-scim-bridge` service to `basic-xs`:
+2. Change the `instance_size_slug` value for the `op-scim-bridge` service to `apps-s-1vcpu-1gb-fixed`:
 
     ```yaml
     services:
     # ...
     - ### ...
-      instance_size_slug: basic-xs
+      instance_size_slug: apps-s-1vcpu-1gb-fixed
       name: op-scim-bridge
     ```
 

--- a/do-app-platform-op-cli/google-workspace/op-scim-bridge-gw.yaml
+++ b/do-app-platform-op-cli/google-workspace/op-scim-bridge-gw.yaml
@@ -13,7 +13,7 @@ services:
     repository: redis
     tag: latest
   instance_count: 1
-  instance_size_slug: basic-xxs
+  instance_size_slug: apps-s-1vcpu-0.5gb
   internal_ports:
   - 6379
   name: op-scim-redis
@@ -42,7 +42,7 @@ services:
     repository: scim
     tag: v2.9.5
   instance_count: 1
-  instance_size_slug: basic-xxs
+  instance_size_slug: apps-s-1vcpu-0.5gb
   name: op-scim-bridge
   routes:
   - path: /

--- a/do-app-platform-op-cli/op-scim-bridge.yaml
+++ b/do-app-platform-op-cli/op-scim-bridge.yaml
@@ -13,7 +13,7 @@ services:
     repository: redis
     tag: latest
   instance_count: 1
-  instance_size_slug: basic-xxs
+  instance_size_slug: apps-s-1vcpu-0.5gb
   internal_ports:
   - 6379
   name: op-scim-redis
@@ -34,7 +34,7 @@ services:
     repository: scim
     tag: v2.9.5
   instance_count: 1
-  instance_size_slug: basic-xxs
+  instance_size_slug: apps-s-1vcpu-0.5gb
   name: op-scim-bridge
   routes:
   - path: /


### PR DESCRIPTION
As of May 7, 2024, DigitalOcean has introduced a new pricing plan for App Platform: [App Platform Release Notes](https://docs.digitalocean.com/release-notes/app-platform/#2024-05-07). The CLI & API now support a new set of slugs to select the plan for each component service: [App Platform Pricing](https://docs.digitalocean.com/products/app-platform/details/pricing/).

As noted by DigitalOcean within the referenced documentation:

> We intend to deprecate legacy plans soon, so we strongly encourage customers to use the new plans when creating or upgrading apps. The new plans offer the same or better pricing and substantially higher egress data allowance.

This PR uses the new minimal plan, `apps-s-1vcpu-0.5gb`, which offers the exact same resource spec and pricing as the former `basic-xxs`. Customers can update an existing app to the new plan using [our existing update instructions](https://github.com/1Password/scim-examples/tree/main/do-app-platform-op-cli#update-your-scim-bridge). No functionality, performance, or pricing changes are expected.

To test:
- deploy SCIM bridge using [current app spec on `main`](https://github.com/1Password/scim-examples/blob/bb0a9af0e2517660decda5912e0df7147edd42f6/do-app-platform-op-cli/op-scim-bridge.yaml)
- update to [new app spec on this branch](https://github.com/1Password/scim-examples/blob/e1f7d613629c101075f1f8a4d34088b2e5ea7d48/do-app-platform-op-cli/op-scim-bridge.yaml) using unchanged update instructions found in the README
- confirm functionality