### PR TITLE
Fix to command in GCP Cloud Run Google Workspace secret README

### DIFF
--- a/beta/google-cloud-run/google-workspace/README.md
+++ b/beta/google-cloud-run/google-workspace/README.md
@@ -65,7 +65,7 @@ In the Cloud Console:
 4. Create a secret from the file:
 
     ```sh
-    gcloud secrets create workspace-settings --data-file=$HOME/workspace-settings.json &&
+    gcloud secrets create workspace-settings --data-file=$HOME/workspace-settings.json
     ```
 
 > [!TIP]


### PR DESCRIPTION
There is a small issue where the existing README had an incorrect command with extra `&&` at the end of the command, likely a small copy/paste aspect that was missed earlier. This command is only used when Google Workspace is the IdP, on a GCP Cloud Run SCIM bridge. 

Tested the updated command with a customer today.