### PR TITLE
Bump to v2.9.6 in CFN & Docker examples

### DIFF
--- a/beta/aws-ecsfargate-cfn/README.md
+++ b/beta/aws-ecsfargate-cfn/README.md
@@ -242,7 +242,7 @@ aws cloudformation deploy \
     --template-file ./op-scim-bridge.yaml \
     --stack-name op-scim-bridge \
     --capabilities CAPABILITY_IAM \
-    --parameter-overrides SCIMBridgeVersion=v2.9.5
+    --parameter-overrides SCIMBridgeVersion=v2.9.6
 ```
 
 > [!IMPORTANT]

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -71,7 +71,7 @@ Parameters:
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: "v2.9.5"
+    Default: "v2.9.6"
     Description: >-
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
   WorkspaceCredentials:

--- a/docker/README.md
+++ b/docker/README.md
@@ -156,7 +156,7 @@ Quarterly review and maintenance is recommended to update the operating system, 
 To use a new version of SCIM bridge, update the `op-scim-bridge_scim` service with the new image tag from the [`1password/scim` repository on Docker Hub](https://hub.docker.com/r/1password/scim/tags):
 
 ```sh
-docker service update op-scim-bridge_scim --image 1password/scim:v2.9.5
+docker service update op-scim-bridge_scim --image 1password/scim:v2.9.6
 ```
 
 Your SCIM bridge should automatically reboot using the specified version, typically in a few seconds.


### PR DESCRIPTION
Version bump to v2.9.6 for our Docker and CloudFormation template deployment examples.