### PR TITLE
Specify ARM64 architecture in Terraform deployment example

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -147,6 +147,11 @@ resource "aws_ecs_task_definition" "op_scim_bridge" {
   cpu                      = 256
   execution_role_arn       = aws_iam_role.op_scim_bridge.arn
 
+  runtime_platform {
+    cpu_architecture         = "ARM64"
+    operating_system_family  = "LINUX"
+  }
+
   tags = local.tags
 }
 


### PR DESCRIPTION
1Password SCIM Bridge [version 2.9.0](https://releases.1password.com/provisioning/scim-bridge/#1password-scim-bridge-2.9.0) introduced ARM64 support (Redis already includes ARM64 support). Our Terraform deployment example does not specify a runtime platform and defaults to x86_64 architecture. ARM64 architecture is preferred for lower cost with no expected performance degradation.

This PR:

- adds a `runtime_platform` block in the ECS task definition
- specifies `cpu_architecture` as `ARM64` and `operating_system_family` as `LINUX`

In testing, the ECS task starts up as expected with the correct `runtime_platform` specification.