### PR TITLE
Update CloudFormation template example and documentation to enable externally managed VPC and DNS

### DIFF
--- a/beta/aws-ecsfargate-cfn/README.md
+++ b/beta/aws-ecsfargate-cfn/README.md
@@ -12,7 +12,9 @@ This example describes how to deploy 1Password SCIM Bridge using [AWS CloudForma
 The included template can be used to deploy 1Password SCIM Bridge as a [stack](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-whatis-concepts.html#cfn-concepts-stacks) using the [AWS CloudFormation console](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console.html) or [the AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-cli.html). The CloudFormation template will create and configure the following resources in your AWS account:
 
 - a VPC (with a `10.0.0.0/16` CIDR block by default)
+  - option to configure a pre-existing VPC by specifying the VPC ID, or leave this field blank to automatically create a new VPC.
 - 2 public subnets (each with `/20` CIDR blocks within this range), spanned across two availability zones in the current or selected region
+  - option to configure pre-existing public subnets using comma-separated values, or leave this field blank to automatically create new subnets.
 - an internet gateway
 - an Application Load Balancer (ALB)
 - an ECS task with associated container definitions for 1Password SCIM Bridge and the requred Redis cache
@@ -23,6 +25,8 @@ The included template can be used to deploy 1Password SCIM Bridge as a [stack](h
 - 2 Route 53 DNS records:
   - for the domain name of your SCIM bridge (e.g. `scim.example.com`)
   - to validate the requested ACM certificate
+  - optional: If left blank, you must manually create validation records with your DNS provider to allow AWS to issue the TLS certificate.
+  
 - AWS Secrets Manager secrets to store credentials and configuration for your SCIM bridge
 - a CloudWatch log group to capture logs
 - required IAM roles

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -4,15 +4,13 @@ Description: >-
   configures a VPC, 2 public subnets, an internet gateway, a route table, an
   ALB, an ACM certificate, Route 53 DNS records, an AWS secret to store
   credentials for your SCIM bridge, security groups, and required IAM roles.
-
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Parameters:
-          - ExistingVPC
+          - VPCID
           - VPCCIDR
-          - ExistingPublicSubnet1
-          - ExistingPublicSubnet2
+          - PublicSubnets
           - Route53HostedZoneID
           - ProvisioningVolume
           - DomainName
@@ -25,14 +23,12 @@ Metadata:
           - WorkspaceCredentials
           - WorkspaceActor
     ParameterLabels:
-      ExistingVPC:
-        default: "Existing VPC (Optional)"
+      VPCID:
+        default: "VPC ID"
       VPCCIDR:
         default: "VPC CIDR"
-      ExistingPublicSubnet1:
-        default: "Existing Public Subnet 1 (if using existing VPC)"
-      ExistingPublicSubnet2:
-        default: "Existing Public Subnet 2 (if using existing VPC)"
+      PublicSubnets:
+        default: "Public subnets"
       Route53HostedZoneID:
         default: "Route 53 hosted zone"
       ProvisioningVolume:
@@ -45,28 +41,26 @@ Metadata:
         default: "Service account key"
       WorkspaceActor:
         default: "Actor"
-
 Parameters:
-  ExistingVPC:
+  VPCID:
     Type: String
-    Default: ""
-    Description: "(Optional) Select an existing VPC. Leave blank to create a new VPC."
+    Description: >-
+      (Optional) ID of an existing VPC to use for your SCIM bridge. If empty, a new VPC and two public subnets will be
+      created.
   VPCCIDR:
     Type: String
     Default: 10.0.0.0/16
-    Description: A CIDR block for the VPC to be created.
-  ExistingPublicSubnet1:
-    Type: String
-    Default: ""
-    Description: "(Optional) Select an existing Public Subnet 1 if using an existing VPC."
-  ExistingPublicSubnet2:
-    Type: String
-    Default: ""
-    Description: "(Optional) Select an existing Public Subnet 2 if using an existing VPC."
+    Description: A CIDR block for the VPC. Required if VPCID is empty; ignored if specifying a VPCID.
+  PublicSubnets:
+    Type: CommaDelimitedList
+    Description: "(Optional) A comma-separated list of two or more public subnets in the specified VPC."
+    ConstraintDescription: >-
+      must be a list of at least two existing subnets associated a unique availability zone in the specified VPC
   Route53HostedZoneID:
     Type: String
-    Default: ""
-    Description: "(Optional) Route 53 Hosted Zone ID for DNS validation. Leave blank if using external DNS provider."
+    Description: >-
+      (Optional) The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB endpoint. If
+      empty, these records must be created in your DNS provider.
   ProvisioningVolume:
     Type: String
     Description: >-
@@ -82,8 +76,7 @@ Parameters:
     Type: String
     Default: scim.example.com
     Description: >-
-      A fully qualified domain name for your SCIM bridge that is in the domain of the selected Route 53 hosted zone
-      where the record will be created.
+      A fully qualified domain name for your SCIM bridge.
   scimsession:
     Type: String
     Description: >-
@@ -108,15 +101,20 @@ Parameters:
     Default: ""
     Description: >-
       The email address of the Google Workspace administrator that the service account is acting on behalf of.
-
-Conditions:
-  CreateNewVPC: !Equals [!Ref ExistingVPC, ""]
-  CreateRoute53Records: !Not [!Equals [!Ref Route53HostedZoneID, ""]]
-  UsingGoogleWorkspace: !Not
-    - !Or
-      - !Equals [!Ref WorkspaceCredentials, ""]
-      - !Equals [!Ref WorkspaceActor, ""]
-
+Rules:
+  ValidateWorkspaceConfig:
+    RuleCondition: !Not
+      - "Fn::EachMemberEquals":
+          - - !Ref WorkspaceCredentials
+            - !Ref WorkspaceActor
+          - ""
+    Assertions:
+      - Assert: !Not [!Equals [!Ref WorkspaceCredentials, ""]]
+        AssertDescription: >-
+          The service account key is required to connect to Google Workspace.
+      - Assert: !Not [!Equals [!Ref WorkspaceActor, ""]]
+        AssertDescription: >-
+          The actor email is required to connect to Google Workspace.
 Mappings:
   CpuScale:
     base:
@@ -144,98 +142,19 @@ Mappings:
       SCIMBridge: 1024
       Redis: 512
       Task: 4096
-
+Conditions:
+  CreateVPC: !Equals [!Ref VPCID, ""]
+  CreateRoute53Records: !Not [!Equals [!Ref Route53HostedZoneID, ""]]
+  UsingGoogleWorkspace: !Not
+    - !Or
+      - !Equals [!Ref WorkspaceCredentials, ""]
+      - !Equals [!Ref WorkspaceActor, ""]
 Resources:
-  VPC:
-    Condition: CreateNewVPC
-    Type: "AWS::EC2::VPC"
-    Properties:
-      CidrBlock: !Ref VPCCIDR
-      EnableDnsHostnames: true
-      EnableDnsSupport: true
-
-  PublicSubnet1:
-    Type: "AWS::EC2::Subnet"
-    Condition: CreateNewVPC
-    Properties:
-      AvailabilityZone:
-        "Fn::Select":
-          - 0
-          - "Fn::GetAZs":
-              Ref: "AWS::Region"
-      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
-      CidrBlock:
-        "Fn::Select":
-          - 0
-          - "Fn::Cidr":
-              - !If [CreateNewVPC, !GetAtt VPC.CidrBlock, !Ref "AWS::NoValue"]
-              - 16
-              - 12
-
-  PublicSubnet2:
-    Type: "AWS::EC2::Subnet"
-    Condition: CreateNewVPC
-    Properties:
-      AvailabilityZone:
-        "Fn::Select":
-          - 1
-          - "Fn::GetAZs":
-              Ref: "AWS::Region"
-      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
-      CidrBlock:
-        "Fn::Select":
-          - 1
-          - "Fn::Cidr":
-              - !If [CreateNewVPC, !GetAtt VPC.CidrBlock, !Ref "AWS::NoValue"]
-              - 16
-              - 12
-
-  InternetGateway:
-    Condition: CreateNewVPC
-    Type: "AWS::EC2::InternetGateway"
-
-  GatewayAttachment:
-    Condition: CreateNewVPC
-    Type: "AWS::EC2::VPCGatewayAttachment"
-    Properties:
-      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
-      InternetGatewayId: !Ref InternetGateway
-
-  RouteTable:
-    Condition: CreateNewVPC
-    Type: "AWS::EC2::RouteTable"
-    Properties:
-      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
-
-  Route:
-    Condition: CreateNewVPC
-    Type: "AWS::EC2::Route"
-    DependsOn: GatewayAttachment
-    Properties:
-      RouteTableId: !Ref RouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId: !Ref InternetGateway
-
-  PublicSubnet1RouteTableAssociation:
-    Condition: CreateNewVPC
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Properties:
-      SubnetId: !Ref PublicSubnet1
-      RouteTableId: !Ref RouteTable
-
-  PublicSubnet2RouteTableAssociation:
-    Condition: CreateNewVPC
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Properties:
-      SubnetId: !Ref PublicSubnet2
-      RouteTableId: !Ref RouteTable
-
   scimsessionSecret:
     Type: "AWS::SecretsManager::Secret"
     Properties:
       SecretString: !Base64
         Ref: scimsession
-
   WorkspaceCredentialsSecret:
     Type: "AWS::SecretsManager::Secret"
     Condition: UsingGoogleWorkspace
@@ -250,9 +169,8 @@ Resources:
         Fn::Base64: !Sub |
           {
             "actor":"${WorkspaceActor}",
-            "bridgeAddress":"https://${DNSRecord}"
+            "bridgeAddress":"https://${DomainName}"
           }
-
   ECSCluster:
     Type: "AWS::ECS::Cluster"
     DependsOn: ExecutionRole
@@ -262,7 +180,6 @@ Resources:
       DefaultCapacityProviderStrategy:
         - CapacityProvider: FARGATE
           Weight: 1
-
   ECSTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"
     Properties:
@@ -282,6 +199,9 @@ Resources:
         - Name: opuser-data
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       TaskRoleArn: !Ref TaskRole
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
       ContainerDefinitions:
         - Name: op-scim-bridge
           Cpu: !FindInMap
@@ -293,6 +213,7 @@ Resources:
             - !Ref ProvisioningVolume
             - SCIMBridge
           Image: !Sub "1password/scim:${SCIMBridgeVersion}"
+          User: "opuser:opuser"
           PortMappings:
             - ContainerPort: 3002
               HostPort: 3002
@@ -324,9 +245,6 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: !Ref LogStream
         - Name: redis
-          DependsOn:
-            - ContainerName: init-redis
-              Condition: COMPLETE
           Cpu: !FindInMap
             - CpuScale
             - !Ref ProvisioningVolume
@@ -338,8 +256,9 @@ Resources:
           Image: "redis:latest"
           User: "redis:redis"
           Command:
-            - "redis-server"
-            - "/home/redis/config/redis.conf"
+            - --maxmemory 256mb
+            - --maxmemory-policy volatile-lru
+            - --save ""
           MountPoints:
             - ContainerPath: /home/redis
               SourceVolume: redis-config
@@ -358,70 +277,12 @@ Resources:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: !Ref LogStream
-
-        - Name: init-host
-          Image: bash
-          Essential: false
-          MountPoints:
-            - ContainerPath: /home/redis
-              SourceVolume: redis-config
-            - ContainerPath: /home/opuser
-              SourceVolume: opuser-data
-          Command:
-            - -c
-            - |
-              echo "Setting directory ownership..." &&
-              chown -R 999:999 /home/redis /home/opuser && echo "Directory ownership assigned!"
-
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-region: !Ref "AWS::Region"
-              awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
-
-        - Name: init-redis
-          Image: bash
-          Essential: false
-          DependsOn:
-            - Condition: COMPLETE
-              ContainerName: init-host
-          User: "999:999"
-          Command:
-            - -c
-            - |
-              sleep 5
-              echo "Creating Redis config directory..." &&
-              mkdir /home/redis/config && echo "Directory created!" &&
-              echo "Writing configuration file..." &&
-              echo $REDIS_CONFIG | base64 -d - | tee /home/redis/config/redis.conf && echo "Configuration file saved!" &&
-              chmod 0440 /home/redis/config/redis.conf && echo "File permissions set!"
-          Environment:
-            - Name: REDIS_CONFIG
-              Value:
-                Fn::Base64: |
-                  # Redis Configuration
-                  maxmemory 256mb
-                  maxmemory-policy volatile-lru
-                  save ""
-          MountPoints:
-            - ContainerPath: /home/redis
-              SourceVolume: redis-config
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-region: !Ref "AWS::Region"
-              awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
-
   LogGroup:
     Type: "AWS::Logs::LogGroup"
-
   LogStream:
     Type: "AWS::Logs::LogStream"
     Properties:
       LogGroupName: !Ref LogGroup
-
   ECSService:
     Type: "AWS::ECS::Service"
     DependsOn: HTTPSListener
@@ -432,25 +293,21 @@ Resources:
         MaximumPercent: 100
         MinimumHealthyPercent: 0
       DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          Subnets:
-            - !If [CreateNewVPC, !Ref PublicSubnet1, !Ref ExistingPublicSubnet1]
-            - !If [CreateNewVPC, !Ref PublicSubnet2, !Ref ExistingPublicSubnet2]
+          Subnets: !If
+            - CreateVPC
+            - [!Ref PublicSubnet1, !Ref PublicSubnet2]
+            - !Ref PublicSubnets
           SecurityGroups:
             - !Ref ServiceSecurityGroup
       LoadBalancers:
         - ContainerName: op-scim-bridge
           ContainerPort: 3002
           TargetGroupArn: !Ref TargetGroup
-
-      HealthCheckGracePeriodSeconds: !If
-        - CreateRoute53Records
-        - 60
-        - !Ref "AWS::NoValue"
-
   TargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
@@ -467,25 +324,24 @@ Resources:
         - Key: deregistration_delay.timeout_seconds
           Value: 60
       TargetType: ip
-      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
-
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
   LoadBalancer:
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
     Properties:
       Scheme: internet-facing
-      Subnets:
-        - !If [CreateNewVPC, !Ref PublicSubnet1, !Ref ExistingPublicSubnet1]
-        - !If [CreateNewVPC, !Ref PublicSubnet2, !Ref ExistingPublicSubnet2]
+      Subnets: !If
+        - CreateVPC
+        - [!Ref PublicSubnet1, !Ref PublicSubnet2]
+        - !Ref PublicSubnets
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
-
   LoadBalancerSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
         Allow public HTTPS ingress to the load balancer from the identity
         provider, restrict egress to the VPC for 1Password SCIM Bridge
-      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 443
@@ -496,17 +352,16 @@ Resources:
           FromPort: 3002
           ToPort: 3002
           CidrIp: !If
-            - CreateNewVPC
+            - CreateVPC
             - !GetAtt VPC.CidrBlock
             - "0.0.0.0/0"
-  
   ServiceSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
         Restrict ingress to ECS Service from load balancer, allow egress to
         1Password.com for 1Password SCIM Bridge.
-      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 3002
@@ -517,7 +372,6 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
-
   HTTPSListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:
@@ -530,7 +384,80 @@ Resources:
       Certificates:
         - CertificateArn: !Ref TLSCertificate
       SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
-
+  ExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ""
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: secrets_manager_policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "secretsmanager:GetSecretValue"
+                Resource:
+                  - !Ref scimsessionSecret
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceCredentialsSecret
+                    - !Ref "AWS::NoValue"
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceSettingsSecret
+                    - !Ref "AWS::NoValue"
+        - PolicyName: inlined_managed_policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  # These were included in the previous version of the template, but may not be needed.
+                  # - "ec2:AuthorizeSecurityGroupIngress"
+                  # - "ec2:Describe*"
+                  # - "ecr:BatchCheckLayerAvailability"
+                  # - "ecr:BatchGetImage"
+                  # - "ecr:GetAuthorizationToken"
+                  # - "ecr:GetDownloadUrlForLayer"
+                  # - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+                  # - "elasticloadbalancing:DeregisterTargets"
+                  # - "elasticloadbalancing:Describe*"
+                  # - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                  # - "elasticloadbalancing:RegisterTargets"
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource:
+                  - arn:aws:logs:*:*:*
+  DNSRecord:
+    Condition: CreateRoute53Records
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      HostedZoneId: !Ref Route53HostedZoneID
+      Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
+      Name: !Ref DomainName
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt LoadBalancer.DNSName
+        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+  TLSCertificate:
+    Type: "AWS::CertificateManager::Certificate"
+    Properties:
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS
+      DomainValidationOptions: !If
+        - CreateRoute53Records
+        - - DomainName: !Ref DomainName
+            HostedZoneId: !Ref Route53HostedZoneID
+        - !Ref "AWS::NoValue"
   TaskRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -564,8 +491,9 @@ Resources:
                   - "ec2:CreateNetworkInterface"
                   - "ec2:DescribeNetworkInterfaces"
                   - "ec2:DeleteNetworkInterface"
-                  - "ec2:Describe*"
-                  - "ec2:AuthorizeSecurityGroupIngress"
+                  # These may not be necessary
+                  # - "ec2:Describe*"
+                  # - "ec2:AuthorizeSecurityGroupIngress"
                 Resource: "*"
         - PolicyName: task_execution_role_policy
           PolicyDocument:
@@ -577,89 +505,88 @@ Resources:
                   - "ecr:BatchCheckLayerAvailability"
                   - "ecr:GetDownloadUrlForLayer"
                   - "ecr:BatchGetImage"
-                  - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-                  - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                  # These may not be necessary
+                  # - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+                  # - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
                 Resource: "*"
-
-  ExecutionRole:
-    Type: "AWS::IAM::Role"
+  VPC:
+    Condition: CreateVPC
+    Type: "AWS::EC2::VPC"
     Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: ""
-            Effect: Allow
-            Principal:
-              Service:
-                - ecs-tasks.amazonaws.com
-            Action: "sts:AssumeRole"
-      Policies:
-        - PolicyName: secrets_manager_policy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "secretsmanager:GetSecretValue"
-                Resource:
-                  - !Ref scimsessionSecret
-                  - !If
-                    - UsingGoogleWorkspace
-                    - !Ref WorkspaceCredentialsSecret
-                    - !Ref "AWS::NoValue"
-                  - !If
-                    - UsingGoogleWorkspace
-                    - !Ref WorkspaceSettingsSecret
-                    - !Ref "AWS::NoValue"
-        - PolicyName: cloudwatch_logging_policy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
-                  - "logs:CreateLogGroup"
-                Resource: 
-                  - arn:aws:logs:*:*:*
-
-  DNSRecord:
-    Condition: CreateRoute53Records
-    Type: "AWS::Route53::RecordSet"
+      CidrBlock: !Ref VPCCIDR
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+  PublicSubnet1:
+    Type: "AWS::EC2::Subnet"
+    Condition: CreateVPC
     Properties:
-      HostedZoneId: !Ref Route53HostedZoneID
-      Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
-      Name: !Ref DomainName
-      Type: A
-      AliasTarget:
-        DNSName: !GetAtt LoadBalancer.DNSName
-        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
-
-  TLSCertificate:
-    Type: "AWS::CertificateManager::Certificate"
+      AvailabilityZone:
+        "Fn::Select":
+          - 0
+          - "Fn::GetAZs":
+              Ref: "AWS::Region"
+      VpcId: !Ref VPC
+      CidrBlock:
+        "Fn::Select":
+          - 0
+          - "Fn::Cidr":
+              - !GetAtt VPC.CidrBlock
+              - 16
+              - 12
+  PublicSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: CreateVPC
     Properties:
-      DomainName: !Ref DomainName
-      ValidationMethod: DNS
-      DomainValidationOptions: !If
-        - CreateRoute53Records
-        - 
-          - DomainName: !Ref DomainName
-            HostedZoneId: !Ref Route53HostedZoneID
-        - !Ref "AWS::NoValue"
-
+      AvailabilityZone:
+        "Fn::Select":
+          - 1
+          - "Fn::GetAZs":
+              Ref: "AWS::Region"
+      VpcId: !Ref VPC
+      CidrBlock:
+        "Fn::Select":
+          - 1
+          - "Fn::Cidr":
+              - !GetAtt VPC.CidrBlock
+              - 16
+              - 12
+  InternetGateway:
+    Condition: CreateVPC
+    Type: "AWS::EC2::InternetGateway"
+  GatewayAttachment:
+    Condition: CreateVPC
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  RouteTable:
+    Condition: CreateVPC
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+  Route:
+    Condition: CreateVPC
+    Type: "AWS::EC2::Route"
+    DependsOn: GatewayAttachment
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  PublicSubnet1RouteTableAssociation:
+    Condition: CreateVPC
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet1
+      RouteTableId: !Ref RouteTable
+  PublicSubnet2RouteTableAssociation:
+    Condition: CreateVPC
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref RouteTable
 Outputs:
   SCIMBridgeURL:
     Description: >-
       The URL for your SCIM bridge. Use this and your bearer token to connect
       your identity provider to 1Password.
-    Value: !If
-      - CreateRoute53Records
-      - !Sub "https://${DNSRecord}"
-      - !Sub "https://${DomainName}"
-
-  SelectedVPC:
-    Description: "The VPC used for the SCIM Bridge."
-    Value: !If
-      - CreateNewVPC
-      - !Ref VPC
-      - !Ref ExistingVPC
+    Value: !Sub "https://${DomainName}"

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -194,9 +194,6 @@ Resources:
         - MemoryScale
         - !Ref ProvisioningVolume
         - Task
-      Volumes:
-        - Name: redis-config
-        - Name: opuser-data
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       TaskRoleArn: !Ref TaskRole
       RuntimePlatform:
@@ -235,9 +232,6 @@ Resources:
               - Name: OP_WORKSPACE_SETTINGS
                 ValueFrom: !Ref WorkspaceSettingsSecret
               - !Ref "AWS::NoValue"
-          MountPoints:
-            - ContainerPath: /home/opuser
-              SourceVolume: opuser-data
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -259,9 +253,6 @@ Resources:
             - --maxmemory 256mb
             - --maxmemory-policy volatile-lru
             - --save ""
-          MountPoints:
-            - ContainerPath: /home/redis
-              SourceVolume: redis-config
           Essential: true
           PortMappings:
             - ContainerPort: 6379

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -563,6 +563,8 @@ Resources:
                   - "ec2:CreateNetworkInterface"
                   - "ec2:DescribeNetworkInterfaces"
                   - "ec2:DeleteNetworkInterface"
+                  - "ec2:Describe*"
+                  - "ec2:AuthorizeSecurityGroupIngress"
                 Resource: "*"
         - PolicyName: task_execution_role_policy
           PolicyDocument:
@@ -574,6 +576,8 @@ Resources:
                   - "ecr:BatchCheckLayerAvailability"
                   - "ecr:GetDownloadUrlForLayer"
                   - "ecr:BatchGetImage"
+                  - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+                  - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
                 Resource: "*"
 
   ExecutionRole:

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -4,11 +4,15 @@ Description: >-
   configures a VPC, 2 public subnets, an internet gateway, a route table, an
   ALB, an ACM certificate, Route 53 DNS records, an AWS secret to store
   credentials for your SCIM bridge, security groups, and required IAM roles.
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Parameters:
+          - ExistingVPC
           - VPCCIDR
+          - ExistingPublicSubnet1
+          - ExistingPublicSubnet2
           - Route53HostedZoneID
           - ProvisioningVolume
           - DomainName
@@ -21,8 +25,14 @@ Metadata:
           - WorkspaceCredentials
           - WorkspaceActor
     ParameterLabels:
+      ExistingVPC:
+        default: "Existing VPC (Optional)"
       VPCCIDR:
         default: "VPC CIDR"
+      ExistingPublicSubnet1:
+        default: "Existing Public Subnet 1 (if using existing VPC)"
+      ExistingPublicSubnet2:
+        default: "Existing Public Subnet 2 (if using existing VPC)"
       Route53HostedZoneID:
         default: "Route 53 hosted zone"
       ProvisioningVolume:
@@ -35,11 +45,24 @@ Metadata:
         default: "Service account key"
       WorkspaceActor:
         default: "Actor"
+
 Parameters:
+  ExistingVPC:
+    Type: String
+    Default: ""
+    Description: "(Optional) Select an existing VPC. Leave blank to create a new VPC."
   VPCCIDR:
     Type: String
     Default: 10.0.0.0/16
     Description: A CIDR block for the VPC to be created.
+  ExistingPublicSubnet1:
+    Type: String
+    Default: ""
+    Description: "(Optional) Select an existing Public Subnet 1 if using an existing VPC."
+  ExistingPublicSubnet2:
+    Type: String
+    Default: ""
+    Description: "(Optional) Select an existing Public Subnet 2 if using an existing VPC."
   Route53HostedZoneID:
     Type: String
     Default: ""
@@ -57,7 +80,7 @@ Parameters:
     ConstraintDescription: must be base, high, or very-high
   DomainName:
     Type: String
-    Default: scim.doucette.io
+    Default: scim.example.com
     Description: >-
       A fully qualified domain name for your SCIM bridge that is in the domain of the selected Route 53 hosted zone
       where the record will be created.
@@ -85,20 +108,15 @@ Parameters:
     Default: ""
     Description: >-
       The email address of the Google Workspace administrator that the service account is acting on behalf of.
-Rules:
-  ValidateWorkspaceConfig:
-    RuleCondition: !Not
-      - "Fn::EachMemberEquals":
-          - - !Ref WorkspaceCredentials
-            - !Ref WorkspaceActor
-          - ""
-    Assertions:
-      - Assert: !Not [!Equals [!Ref WorkspaceCredentials, ""]]
-        AssertDescription: >-
-          The service account key is required to connect to Google Workspace.
-      - Assert: !Not [!Equals [!Ref WorkspaceActor, ""]]
-        AssertDescription: >-
-          The actor email is required to connect to Google Workspace.
+
+Conditions:
+  CreateNewVPC: !Equals [!Ref ExistingVPC, ""]
+  CreateRoute53Records: !Not [!Equals [!Ref Route53HostedZoneID, ""]]
+  UsingGoogleWorkspace: !Not
+    - !Or
+      - !Equals [!Ref WorkspaceCredentials, ""]
+      - !Equals [!Ref WorkspaceActor, ""]
+
 Mappings:
   CpuScale:
     base:
@@ -126,34 +144,97 @@ Mappings:
       SCIMBridge: 1024
       Redis: 512
       Task: 4096
-Conditions:
-  CreateRoute53Records: !Not [!Equals [!Ref Route53HostedZoneID, ""]]
-  UsingGoogleWorkspace: !Not
-    - !Or
-      - !Equals [!Ref WorkspaceCredentials, ""]
-      - !Equals [!Ref WorkspaceActor, ""]
+
 Resources:
+  VPC:
+    Condition: CreateNewVPC
+    Type: "AWS::EC2::VPC"
+    Properties:
+      CidrBlock: !Ref VPCCIDR
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+
+  PublicSubnet1:
+    Type: "AWS::EC2::Subnet"
+    Condition: CreateNewVPC
+    Properties:
+      AvailabilityZone:
+        "Fn::Select":
+          - 0
+          - "Fn::GetAZs":
+              Ref: "AWS::Region"
+      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
+      CidrBlock:
+        "Fn::Select":
+          - 0
+          - "Fn::Cidr":
+              - !GetAtt VPC.CidrBlock
+              - 16
+              - 12
+
+  PublicSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: CreateNewVPC
+    Properties:
+      AvailabilityZone:
+        "Fn::Select":
+          - 1
+          - "Fn::GetAZs":
+              Ref: "AWS::Region"
+      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
+      CidrBlock:
+        "Fn::Select":
+          - 1
+          - "Fn::Cidr":
+              - !GetAtt VPC.CidrBlock
+              - 16
+              - 12
+
+  InternetGateway:
+    Condition: CreateNewVPC
+    Type: "AWS::EC2::InternetGateway"
+
+  GatewayAttachment:
+    Condition: CreateNewVPC
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  
+  RouteTable:
+    Condition: CreateNewVPC
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+
+  Route:
+    Condition: CreateNewVPC
+    Type: "AWS::EC2::Route"
+    DependsOn: GatewayAttachment
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1RouteTableAssociation:
+    Condition: CreateNewVPC
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet1
+      RouteTableId: !Ref RouteTable
+
+  PublicSubnet2RouteTableAssociation:
+    Condition: CreateNewVPC
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref RouteTable
+
   scimsessionSecret:
     Type: "AWS::SecretsManager::Secret"
     Properties:
       SecretString: !Base64
         Ref: scimsession
-  WorkspaceCredentialsSecret:
-    Type: "AWS::SecretsManager::Secret"
-    Condition: UsingGoogleWorkspace
-    Properties:
-      SecretString: !Base64
-        Ref: WorkspaceCredentials
-  WorkspaceSettingsSecret:
-    Type: "AWS::SecretsManager::Secret"
-    Condition: UsingGoogleWorkspace
-    Properties:
-      SecretString:
-        Fn::Base64: !Sub |
-          {
-            "actor":"${WorkspaceActor}",
-            "bridgeAddress":"https://${DNSRecord}"
-          }
 
   ECSCluster:
     Type: "AWS::ECS::Cluster"
@@ -164,6 +245,7 @@ Resources:
       DefaultCapacityProviderStrategy:
         - CapacityProvider: FARGATE
           Weight: 1
+
   ECSTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"
     Properties:
@@ -194,7 +276,6 @@ Resources:
             - !Ref ProvisioningVolume
             - SCIMBridge
           Image: !Sub "1password/scim:${SCIMBridgeVersion}"
-          User: "opuser:opuser"
           PortMappings:
             - ContainerPort: 3002
               HostPort: 3002
@@ -206,16 +287,6 @@ Resources:
           Secrets:
             - Name: OP_SESSION
               ValueFrom: !Ref scimsessionSecret
-            - !If
-              - UsingGoogleWorkspace
-              - Name: OP_WORKSPACE_CREDENTIALS
-                ValueFrom: !Ref WorkspaceCredentialsSecret
-              - !Ref "AWS::NoValue"
-            - !If
-              - UsingGoogleWorkspace
-              - Name: OP_WORKSPACE_SETTINGS
-                ValueFrom: !Ref WorkspaceSettingsSecret
-              - !Ref "AWS::NoValue"
           MountPoints:
             - ContainerPath: /home/opuser
               SourceVolume: opuser-data
@@ -235,17 +306,6 @@ Resources:
             - !Ref ProvisioningVolume
             - Redis
           Image: "redis:latest"
-          User: "redis:redis"
-          Command:
-            - "redis-server"
-            - "/home/redis/config/redis.conf"
-          MountPoints:
-            - ContainerPath: /home/redis
-              SourceVolume: redis-config
-          Essential: true
-          DependsOn:
-            - Condition: COMPLETE
-              ContainerName: init-redis
           PortMappings:
             - ContainerPort: 6379
               HostPort: 6379
@@ -260,68 +320,15 @@ Resources:
               awslogs-region: !Ref "AWS::Region"
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: !Ref LogStream
-        - Name: init-host
-          Image: bash
-          Essential: false
-          MountPoints:
-            - ContainerPath: /home/redis
-              SourceVolume: redis-config
-            - ContainerPath: /home/opuser
-              SourceVolume: opuser-data
-          Command:
-            - -c
-            - echo "Setting directory ownership..." &&
-              chown -R 999:999 /home/redis /home/opuser && echo "Directory ownership assigned!"
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-region: !Ref "AWS::Region"
-              awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
-        - Name: init-redis
-          Image: bash
-          Essential: false
-          DependsOn:
-            - Condition: COMPLETE
-              ContainerName: init-host
-          User: "999:999"
-          Command:
-            - -c
-            - echo "Creating Redis config directory..." &&
-              mkdir /home/redis/config && echo "Directory created!" &&
-              echo "Writing configuration file..." &&
-              echo $REDIS_CONFIG | base64 -d - | tee /home/redis/config/redis.conf && echo "Configuration file saved!" &&
-              echo "Setting configuration file permissions..." &&
-              chmod 0440 /home/redis/config/redis.conf && echo "File permissions set!"
-          Environment:
-            - Name: REDIS_CONFIG
-              Value:
-                Fn::Base64: |
-                  # Configure Redis as cache
 
-                  # Cache memory limit
-                  maxmemory 256mb
-
-                  # Evict only expired keys when memory limit is reached using least recently used algorithm
-                  maxmemory-policy volatile-lru
-
-                  # Disable snapshotting
-                  save ""
-          MountPoints:
-            - ContainerPath: /home/redis
-              SourceVolume: redis-config
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-region: !Ref "AWS::Region"
-              awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref LogStream
   LogGroup:
     Type: "AWS::Logs::LogGroup"
+
   LogStream:
     Type: "AWS::Logs::LogStream"
     Properties:
       LogGroupName: !Ref LogGroup
+
   ECSService:
     Type: "AWS::ECS::Service"
     DependsOn: HTTPSListener
@@ -332,20 +339,25 @@ Resources:
         MaximumPercent: 100
         MinimumHealthyPercent: 0
       DesiredCount: 1
-      HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
           Subnets:
-            - !Ref PublicSubnet1
-            - !Ref PublicSubnet2
+            - !If [CreateNewVPC, !Ref PublicSubnet1, !Ref ExistingPublicSubnet1]
+            - !If [CreateNewVPC, !Ref PublicSubnet2, !Ref ExistingPublicSubnet2]
           SecurityGroups:
             - !Ref ServiceSecurityGroup
       LoadBalancers:
         - ContainerName: op-scim-bridge
           ContainerPort: 3002
           TargetGroupArn: !Ref TargetGroup
+
+      HealthCheckGracePeriodSeconds: !If
+        - CreateRoute53Records
+        - 60
+        - !Ref "AWS::NoValue"
+
   TargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
@@ -362,24 +374,25 @@ Resources:
         - Key: deregistration_delay.timeout_seconds
           Value: 60
       TargetType: ip
-      VpcId: !Ref VPC
+      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
+
   LoadBalancer:
-    DependsOn: GatewayAttachment
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
     Properties:
       Scheme: internet-facing
       Subnets:
-        - !Ref PublicSubnet1
-        - !Ref PublicSubnet2
+        - !If [CreateNewVPC, !Ref PublicSubnet1, !Ref ExistingPublicSubnet1]
+        - !If [CreateNewVPC, !Ref PublicSubnet2, !Ref ExistingPublicSubnet2]
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
+
   LoadBalancerSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
         Allow public HTTPS ingress to the load balancer from the identity
         provider, restrict egress to the VPC for 1Password SCIM Bridge
-      VpcId: !Ref VPC
+      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 443
@@ -390,13 +403,14 @@ Resources:
           FromPort: 3002
           ToPort: 3002
           CidrIp: !GetAtt VPC.CidrBlock
+
   ServiceSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
         Restrict ingress to ECS Service from load balancer, allow egress to
         1Password.com for 1Password SCIM Bridge.
-      VpcId: !Ref VPC
+      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 3002
@@ -407,6 +421,7 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+
   HTTPSListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:
@@ -418,79 +433,7 @@ Resources:
       Protocol: HTTPS
       Certificates:
         - CertificateArn: !Ref TLSCertificate
-  ExecutionRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: ""
-            Effect: Allow
-            Principal:
-              Service:
-                - ecs-tasks.amazonaws.com
-            Action: "sts:AssumeRole"
-      Policies:
-        - PolicyName: secrets_manager_policy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "secretsmanager:GetSecretValue"
-                Resource:
-                  - !Ref scimsessionSecret
-                  - !If
-                    - UsingGoogleWorkspace
-                    - !Ref WorkspaceCredentialsSecret
-                    - !Ref "AWS::NoValue"
-                  - !If
-                    - UsingGoogleWorkspace
-                    - !Ref WorkspaceSettingsSecret
-                    - !Ref "AWS::NoValue"
-        - PolicyName: inlined_managed_policy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "ec2:AuthorizeSecurityGroupIngress"
-                  - "ec2:Describe*"
-                  - "ecr:BatchCheckLayerAvailability"
-                  - "ecr:BatchGetImage"
-                  - "ecr:GetAuthorizationToken"
-                  - "ecr:GetDownloadUrlForLayer"
-                  - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-                  - "elasticloadbalancing:DeregisterTargets"
-                  - "elasticloadbalancing:Describe*"
-                  - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
-                  - "elasticloadbalancing:RegisterTargets"
-                  - "logs:CreateLogGroup"
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
-                Resource: "*"
-  DNSRecord:
-    Condition: CreateRoute53Records
-    Type: "AWS::Route53::RecordSet"
-    Properties:
-      HostedZoneId: !Ref Route53HostedZoneID
-      Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
-      Name: !Ref DomainName
-      Type: A
-      AliasTarget:
-        DNSName: !GetAtt LoadBalancer.DNSName
-        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
-  TLSCertificate:
-    Type: "AWS::CertificateManager::Certificate"
-    Properties:
-      DomainName: !Ref DomainName
-      ValidationMethod: DNS  # Always use DNS validation
-      DomainValidationOptions: !If
-        - CreateRoute53Records
-        - 
-          - DomainName: !Ref DomainName
-            HostedZoneId: !Ref Route53HostedZoneID
-        - !Ref "AWS::NoValue"  # No HostedZoneId for external DNS, you will need to manually create CNAME
+
   TaskRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -536,72 +479,65 @@ Resources:
                   - "ecr:GetDownloadUrlForLayer"
                   - "ecr:BatchGetImage"
                 Resource: "*"
-  VPC:
-    Type: "AWS::EC2::VPC"
+
+  ExecutionRole:
+    Type: "AWS::IAM::Role"
     Properties:
-      CidrBlock: !Ref VPCCIDR
-      EnableDnsHostnames: true
-      EnableDnsSupport: true
-  PublicSubnet1:
-    Type: "AWS::EC2::Subnet"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ""
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: secrets_manager_policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "secretsmanager:GetSecretValue"
+                Resource:
+                  - !Ref scimsessionSecret
+        - PolicyName: cloudwatch_logging_policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                  - "logs:CreateLogGroup"
+                Resource: 
+                  - arn:aws:logs:*:*:*
+
+  DNSRecord:
+    Condition: CreateRoute53Records
+    Type: "AWS::Route53::RecordSet"
     Properties:
-      AvailabilityZone:
-        "Fn::Select":
-          - 0
-          - "Fn::GetAZs":
-              Ref: "AWS::Region"
-      VpcId: !Ref VPC
-      CidrBlock:
-        "Fn::Select":
-          - 0
-          - "Fn::Cidr":
-              - !GetAtt VPC.CidrBlock
-              - 16
-              - 12
-  PublicSubnet2:
-    Type: "AWS::EC2::Subnet"
+      HostedZoneId: !Ref Route53HostedZoneID
+      Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
+      Name: !Ref DomainName
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt LoadBalancer.DNSName
+        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+
+  TLSCertificate:
+    Type: "AWS::CertificateManager::Certificate"
     Properties:
-      AvailabilityZone:
-        "Fn::Select":
-          - 1
-          - "Fn::GetAZs":
-              Ref: "AWS::Region"
-      VpcId: !Ref VPC
-      CidrBlock:
-        "Fn::Select":
-          - 1
-          - "Fn::Cidr":
-              - !GetAtt VPC.CidrBlock
-              - 16
-              - 12
-  InternetGateway:
-    Type: "AWS::EC2::InternetGateway"
-  GatewayAttachment:
-    Type: "AWS::EC2::VPCGatewayAttachment"
-    Properties:
-      VpcId: !Ref VPC
-      InternetGatewayId: !Ref InternetGateway
-  RouteTable:
-    Type: "AWS::EC2::RouteTable"
-    Properties:
-      VpcId: !Ref VPC
-  Route:
-    Type: "AWS::EC2::Route"
-    DependsOn: GatewayAttachment
-    Properties:
-      RouteTableId: !Ref RouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId: !Ref InternetGateway
-  PublicSubnet1RouteTableAssociation:
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Properties:
-      SubnetId: !Ref PublicSubnet1
-      RouteTableId: !Ref RouteTable
-  PublicSubnet2RouteTableAssociation:
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Properties:
-      SubnetId: !Ref PublicSubnet2
-      RouteTableId: !Ref RouteTable
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS
+      DomainValidationOptions: !If
+        - CreateRoute53Records
+        - 
+          - DomainName: !Ref DomainName
+            HostedZoneId: !Ref Route53HostedZoneID
+        - !Ref "AWS::NoValue"
+
 Outputs:
   SCIMBridgeURL:
     Description: >-
@@ -611,3 +547,10 @@ Outputs:
       - CreateRoute53Records
       - !Sub "https://${DNSRecord}"
       - !Sub "https://${DomainName}"
+
+  SelectedVPC:
+    Description: "The VPC used for the SCIM Bridge."
+    Value: !If
+      - CreateNewVPC
+      - !Ref VPC
+      - !Ref ExistingVPC

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -1,9 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  Deploys 1Password SCIM Bridge using Amazon ECS and AWS Fargate. Provisions and
-  configures a VPC, 2 public subnets, an internet gateway, a route table, an
-  ALB, an ACM certificate, Route 53 DNS records, an AWS secret to store
-  credentials for your SCIM bridge, security groups, and required IAM roles.
+  Deploys 1Password SCIM Bridge on AWS Fargate in an Amazon ECS cluster. Includes ALB, ACM certificate, AWS secret,
+  security groups, and IAM role resources. Optionally creates Route 53 records and a VPC with 2 public subnets,
+  internet gateway, and route table.
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -145,6 +144,7 @@ Mappings:
 Conditions:
   CreateVPC: !Equals [!Ref VPCID, ""]
   CreateRoute53Records: !Not [!Equals [!Ref Route53HostedZoneID, ""]]
+  OutputDNSRecordContent: !Not [Condition: CreateRoute53Records]
   UsingGoogleWorkspace: !Not
     - !Or
       - !Equals [!Ref WorkspaceCredentials, ""]
@@ -247,7 +247,7 @@ Resources:
             - MemoryScale
             - !Ref ProvisioningVolume
             - Redis
-          Image: "redis:latest"
+          Image: "redis"
           User: "redis:redis"
           Command:
             - --maxmemory 256mb
@@ -471,7 +471,7 @@ Resources:
                   - "ec2:DescribeNetworkInterfaces"
                   - "ec2:DeleteNetworkInterface"
                 Resource: "*"
-  
+
   VPC:
     Condition: CreateVPC
     Type: "AWS::EC2::VPC"
@@ -548,6 +548,18 @@ Resources:
       SubnetId: !Ref PublicSubnet2
       RouteTableId: !Ref RouteTable
 Outputs:
+  CNAMEName:
+    Condition: OutputDNSRecordContent
+    Description: >-
+      Name of a DNS record to point to the load balancer. Use with CNAMEValue to create a CNAME record in your DNS
+      provider.
+    Value: !Sub "${DomainName}."
+  CNAMEValue:
+    Condition: OutputDNSRecordContent
+    Description: >-
+      Value of a DNS record to point to the load balancer. Use with CNAMEName to create a public CNAME record in your
+      DNS provider.
+    Value: !Sub "${LoadBalancer.DNSName}."
   SCIMBridgeURL:
     Description: >-
       The URL for your SCIM bridge. Use this and your bearer token to connect

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -168,7 +168,7 @@ Resources:
         "Fn::Select":
           - 0
           - "Fn::Cidr":
-              - !GetAtt VPC.CidrBlock
+              - !If [CreateNewVPC, !GetAtt VPC.CidrBlock, !Ref "AWS::NoValue"]
               - 16
               - 12
 
@@ -186,7 +186,7 @@ Resources:
         "Fn::Select":
           - 1
           - "Fn::Cidr":
-              - !GetAtt VPC.CidrBlock
+              - !If [CreateNewVPC, !GetAtt VPC.CidrBlock, !Ref "AWS::NoValue"]
               - 16
               - 12
 
@@ -198,14 +198,14 @@ Resources:
     Condition: CreateNewVPC
     Type: "AWS::EC2::VPCGatewayAttachment"
     Properties:
-      VpcId: !Ref VPC
+      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
       InternetGatewayId: !Ref InternetGateway
-  
+
   RouteTable:
     Condition: CreateNewVPC
     Type: "AWS::EC2::RouteTable"
     Properties:
-      VpcId: !Ref VPC
+      VpcId: !If [CreateNewVPC, !Ref VPC, !Ref ExistingVPC]
 
   Route:
     Condition: CreateNewVPC
@@ -235,6 +235,23 @@ Resources:
     Properties:
       SecretString: !Base64
         Ref: scimsession
+
+  WorkspaceCredentialsSecret:
+    Type: "AWS::SecretsManager::Secret"
+    Condition: UsingGoogleWorkspace
+    Properties:
+      SecretString: !Base64
+        Ref: WorkspaceCredentials
+  WorkspaceSettingsSecret:
+    Type: "AWS::SecretsManager::Secret"
+    Condition: UsingGoogleWorkspace
+    Properties:
+      SecretString:
+        Fn::Base64: !Sub |
+          {
+            "actor":"${WorkspaceActor}",
+            "bridgeAddress":"https://${DNSRecord}"
+          }
 
   ECSCluster:
     Type: "AWS::ECS::Cluster"
@@ -287,6 +304,16 @@ Resources:
           Secrets:
             - Name: OP_SESSION
               ValueFrom: !Ref scimsessionSecret
+            - !If
+              - UsingGoogleWorkspace
+              - Name: OP_WORKSPACE_CREDENTIALS
+                ValueFrom: !Ref WorkspaceCredentialsSecret
+              - !Ref "AWS::NoValue"
+            - !If
+              - UsingGoogleWorkspace
+              - Name: OP_WORKSPACE_SETTINGS
+                ValueFrom: !Ref WorkspaceSettingsSecret
+              - !Ref "AWS::NoValue"
           MountPoints:
             - ContainerPath: /home/opuser
               SourceVolume: opuser-data
@@ -297,6 +324,9 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: !Ref LogStream
         - Name: redis
+          DependsOn:
+            - ContainerName: init-redis
+              Condition: COMPLETE
           Cpu: !FindInMap
             - CpuScale
             - !Ref ProvisioningVolume
@@ -306,6 +336,14 @@ Resources:
             - !Ref ProvisioningVolume
             - Redis
           Image: "redis:latest"
+          User: "redis:redis"
+          Command:
+            - "redis-server"
+            - "/home/redis/config/redis.conf"
+          MountPoints:
+            - ContainerPath: /home/redis
+              SourceVolume: redis-config
+          Essential: true
           PortMappings:
             - ContainerPort: 6379
               HostPort: 6379
@@ -314,6 +352,61 @@ Resources:
             Command:
               - "CMD-SHELL"
               - "redis-cli ping | grep PONG"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: !Ref LogStream
+
+        - Name: init-host
+          Image: bash
+          Essential: false
+          MountPoints:
+            - ContainerPath: /home/redis
+              SourceVolume: redis-config
+            - ContainerPath: /home/opuser
+              SourceVolume: opuser-data
+          Command:
+            - -c
+            - |
+              echo "Setting directory ownership..." &&
+              chown -R 999:999 /home/redis /home/opuser && echo "Directory ownership assigned!"
+
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: !Ref LogStream
+
+        - Name: init-redis
+          Image: bash
+          Essential: false
+          DependsOn:
+            - Condition: COMPLETE
+              ContainerName: init-host
+          User: "999:999"
+          Command:
+            - -c
+            - |
+              sleep 5
+              echo "Creating Redis config directory..." &&
+              mkdir /home/redis/config && echo "Directory created!" &&
+              echo "Writing configuration file..." &&
+              echo $REDIS_CONFIG | base64 -d - | tee /home/redis/config/redis.conf && echo "Configuration file saved!" &&
+              chmod 0440 /home/redis/config/redis.conf && echo "File permissions set!"
+          Environment:
+            - Name: REDIS_CONFIG
+              Value:
+                Fn::Base64: |
+                  # Redis Configuration
+                  maxmemory 256mb
+                  maxmemory-policy volatile-lru
+                  save ""
+          MountPoints:
+            - ContainerPath: /home/redis
+              SourceVolume: redis-config
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -402,8 +495,11 @@ Resources:
         - IpProtocol: tcp
           FromPort: 3002
           ToPort: 3002
-          CidrIp: !GetAtt VPC.CidrBlock
-
+          CidrIp: !If
+            - CreateNewVPC
+            - !GetAtt VPC.CidrBlock
+            - "0.0.0.0/0"
+  
   ServiceSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
@@ -502,6 +598,14 @@ Resources:
                   - "secretsmanager:GetSecretValue"
                 Resource:
                   - !Ref scimsessionSecret
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceCredentialsSecret
+                    - !Ref "AWS::NoValue"
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceSettingsSecret
+                    - !Ref "AWS::NoValue"
         - PolicyName: cloudwatch_logging_policy
           PolicyDocument:
             Version: 2012-10-17

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -16,30 +16,29 @@ Metadata:
           - SCIMBridgeVersion
           - scimsession
       - Label:
-          default: >-
-            Workspace configuration (only for customers integrating with Google Workspace)
+          default: Workspace configuration (only for customers integrating with Google Workspace)
         Parameters:
           - WorkspaceCredentials
           - WorkspaceActor
     ParameterLabels:
       VPCID:
-        default: "VPC ID"
+        default: VPC ID
       VPCCIDR:
-        default: "VPC CIDR"
+        default: VPC CIDR
       PublicSubnets:
-        default: "Public subnets"
+        default: Public subnets
       Route53HostedZoneID:
-        default: "Route 53 hosted zone"
+        default: Route 53 hosted zone
       ProvisioningVolume:
-        default: "Provisioning volume"
+        default: Provisioning volume
       DomainName:
-        default: "1Password SCIM Bridge domain name"
+        default: 1Password SCIM Bridge domain name
       SCIMBridgeVersion:
-        default: "1Password SCIM Bridge version"
+        default: 1Password SCIM Bridge version
       WorkspaceCredentials:
-        default: "Service account key"
+        default: Service account key
       WorkspaceActor:
-        default: "Actor"
+        default: Actor
 Parameters:
   VPCID:
     Type: String
@@ -52,7 +51,7 @@ Parameters:
     Description: A CIDR block for the VPC. Required if VPCID is empty; ignored if specifying a VPCID.
   PublicSubnets:
     Type: CommaDelimitedList
-    Description: "(Optional) A comma-separated list of two or more public subnets in the specified VPC."
+    Description: (Optional) A comma-separated list of two or more public subnets in the specified VPC.
     ConstraintDescription: >-
       must be a list of at least two existing subnets associated a unique availability zone in the specified VPC
   Route53HostedZoneID:
@@ -81,12 +80,12 @@ Parameters:
     Description: >-
       The plain text contents of the scimsession file created during the automated user provisioning setup in your
       1Password account.
-    MinLength: "1"
-    ConstraintDescription: "must not be empty"
+    MinLength: 1
+    ConstraintDescription: must not be empty
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: "v2.9.6"
+    Default: v2.9.6
     Description: >-
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
   WorkspaceCredentials:
@@ -103,7 +102,7 @@ Parameters:
 Rules:
   ValidateWorkspaceConfig:
     RuleCondition: !Not
-      - "Fn::EachMemberEquals":
+      - Fn::EachMemberEquals:
           - - !Ref WorkspaceCredentials
             - !Ref WorkspaceActor
           - ""
@@ -151,28 +150,25 @@ Conditions:
       - !Equals [!Ref WorkspaceActor, ""]
 Resources:
   scimsessionSecret:
-    Type: "AWS::SecretsManager::Secret"
+    Type: AWS::SecretsManager::Secret
     Properties:
-      SecretString: !Base64
-        Ref: scimsession
+      SecretString: !Ref scimsession
   WorkspaceCredentialsSecret:
-    Type: "AWS::SecretsManager::Secret"
+    Type: AWS::SecretsManager::Secret
     Condition: UsingGoogleWorkspace
     Properties:
-      SecretString: !Base64
-        Ref: WorkspaceCredentials
+      SecretString: !Ref WorkspaceCredentials
   WorkspaceSettingsSecret:
-    Type: "AWS::SecretsManager::Secret"
+    Type: AWS::SecretsManager::Secret
     Condition: UsingGoogleWorkspace
     Properties:
-      SecretString:
-        Fn::Base64: !Sub |
-          {
-            "actor":"${WorkspaceActor}",
-            "bridgeAddress":"https://${DomainName}"
-          }
+      SecretString: !Sub |-
+        {
+          "actor":"${WorkspaceActor}",
+          "bridgeAddress":"https://${DomainName}"
+        }
   ECSCluster:
-    Type: "AWS::ECS::Cluster"
+    Type: AWS::ECS::Cluster
     DependsOn: ExecutionRole
     Properties:
       CapacityProviders:
@@ -181,8 +177,9 @@ Resources:
         - CapacityProvider: FARGATE
           Weight: 1
   ECSTaskDefinition:
-    Type: "AWS::ECS::TaskDefinition"
+    Type: AWS::ECS::TaskDefinition
     Properties:
+      Family: op-scim-bridge
       RequiresCompatibilities:
         - FARGATE
       NetworkMode: awsvpc
@@ -199,7 +196,54 @@ Resources:
       RuntimePlatform:
         CpuArchitecture: ARM64
         OperatingSystemFamily: LINUX
+      Volumes:
+        - Name: secrets
       ContainerDefinitions:
+        - Name: mount-secrets
+          Essential: false
+          Image: amazon/aws-cli
+          MountPoints:
+            - ContainerPath: /aws
+              SourceVolume: secrets
+          Environment:
+            - Name: SCIMSESSION_ARN
+              Value: !Ref scimsessionSecret
+            - !If
+                - UsingGoogleWorkspace
+                - Name: WORKSPACE_CREDENTIALS_ARN
+                  Value: !Ref WorkspaceCredentialsSecret
+                - !Ref AWS::NoValue
+            - !If
+                - UsingGoogleWorkspace
+                - Name: WORKSPACE_SETTINGS_ARN
+                  Value: !Ref WorkspaceSettingsSecret
+                - !Ref AWS::NoValue
+          EntryPoint:
+            - /bin/bash
+            - -c
+          Command:
+            - !Join
+              - " "
+              - - >-
+                  aws secretsmanager get-secret-value
+                  --secret-id $SCIMSESSION_ARN --query SecretString --output text
+                  > scimsession
+                - !If
+                    - UsingGoogleWorkspace
+                    - >-
+                      && aws secretsmanager get-secret-value
+                      --secret-id $WORKSPACE_CREDENTIALS_ARN --query SecretString --output text
+                      > workspace-credentials.json
+                      && aws secretsmanager get-secret-value
+                      --secret-id $WORKSPACE_SETTINGS_ARN --query SecretString --output text
+                      > workspace-settings.json
+                    - !Ref AWS::NoValue
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: !Ref LogStream
         - Name: op-scim-bridge
           Cpu: !FindInMap
             - CpuScale
@@ -209,33 +253,21 @@ Resources:
             - MemoryScale
             - !Ref ProvisioningVolume
             - SCIMBridge
-          Image: !Sub "1password/scim:${SCIMBridgeVersion}"
-          User: "opuser:opuser"
-          PortMappings:
-            - ContainerPort: 3002
-              HostPort: 3002
-              Protocol: tcp
-          Essential: true
+          Image: !Sub 1password/scim:${SCIMBridgeVersion}
+          User: opuser:opuser
+          PortMappings: [ContainerPort: 3002]
           DependsOn:
+            - ContainerName: mount-secrets
+              Condition: SUCCESS
             - ContainerName: redis
               Condition: HEALTHY
-          Secrets:
-            - Name: OP_SESSION
-              ValueFrom: !Ref scimsessionSecret
-            - !If
-              - UsingGoogleWorkspace
-              - Name: OP_WORKSPACE_CREDENTIALS
-                ValueFrom: !Ref WorkspaceCredentialsSecret
-              - !Ref "AWS::NoValue"
-            - !If
-              - UsingGoogleWorkspace
-              - Name: OP_WORKSPACE_SETTINGS
-                ValueFrom: !Ref WorkspaceSettingsSecret
-              - !Ref "AWS::NoValue"
+          MountPoints:
+            - ContainerPath: /home/opuser/.op
+              SourceVolume: secrets
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-region: !Ref "AWS::Region"
+              awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: !Ref LogStream
         - Name: redis
@@ -247,42 +279,35 @@ Resources:
             - MemoryScale
             - !Ref ProvisioningVolume
             - Redis
-          Image: "redis"
-          User: "redis:redis"
+          Image: redis
+          User: redis:redis
           Command:
             - --maxmemory 256mb
             - --maxmemory-policy volatile-lru
             - --save ""
-          Essential: true
-          PortMappings:
-            - ContainerPort: 6379
-              HostPort: 6379
-              Protocol: tcp
+          PortMappings: [ContainerPort: 6379]
           HealthCheck:
             Command:
-              - "CMD-SHELL"
-              - "redis-cli ping | grep PONG"
+              - CMD-SHELL
+              - redis-cli ping | grep PONG
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-region: !Ref "AWS::Region"
+              awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: !Ref LogStream
   LogGroup:
-    Type: "AWS::Logs::LogGroup"
+    Type: AWS::Logs::LogGroup
   LogStream:
-    Type: "AWS::Logs::LogStream"
+    Type: AWS::Logs::LogStream
     Properties:
       LogGroupName: !Ref LogGroup
   ECSService:
-    Type: "AWS::ECS::Service"
+    Type: AWS::ECS::Service
     DependsOn: HTTPSListener
     Properties:
       Cluster: !Ref ECSCluster
       TaskDefinition: !Ref ECSTaskDefinition
-      DeploymentConfiguration:
-        MaximumPercent: 100
-        MinimumHealthyPercent: 0
       DesiredCount: 1
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
@@ -300,12 +325,12 @@ Resources:
           ContainerPort: 3002
           TargetGroupArn: !Ref TargetGroup
   TargetGroup:
-    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /ping
       Matcher:
-        HttpCode: "200,301,302"
+        HttpCode: 200,301,302
       HealthCheckTimeoutSeconds: 5
       UnhealthyThresholdCount: 2
       HealthyThresholdCount: 2
@@ -317,7 +342,7 @@ Resources:
       TargetType: ip
       VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
   LoadBalancer:
-    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Scheme: internet-facing
       Subnets: !If
@@ -327,7 +352,7 @@ Resources:
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
   LoadBalancerSecurityGroup:
-    Type: "AWS::EC2::SecurityGroup"
+    Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: >-
         Allow public HTTPS ingress to the load balancer from the identity
@@ -345,9 +370,9 @@ Resources:
           CidrIp: !If
             - CreateVPC
             - !GetAtt VPC.CidrBlock
-            - "0.0.0.0/0"
+            - 0.0.0.0/0
   ServiceSecurityGroup:
-    Type: "AWS::EC2::SecurityGroup"
+    Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: >-
         Restrict ingress to ECS Service from load balancer, allow egress to
@@ -364,7 +389,7 @@ Resources:
           ToPort: 443
           CidrIp: 0.0.0.0/0
   HTTPSListener:
-    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
         - Type: forward
@@ -376,7 +401,7 @@ Resources:
         - CertificateArn: !Ref TLSCertificate
       SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
   ExecutionRole:
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -386,39 +411,22 @@ Resources:
             Principal:
               Service:
                 - ecs-tasks.amazonaws.com
-            Action: "sts:AssumeRole"
+            Action: sts:AssumeRole
       Policies:
-        - PolicyName: secrets_manager_policy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "secretsmanager:GetSecretValue"
-                Resource:
-                  - !Ref scimsessionSecret
-                  - !If
-                    - UsingGoogleWorkspace
-                    - !Ref WorkspaceCredentialsSecret
-                    - !Ref "AWS::NoValue"
-                  - !If
-                    - UsingGoogleWorkspace
-                    - !Ref WorkspaceSettingsSecret
-                    - !Ref "AWS::NoValue"
         - PolicyName: inlined_managed_policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
-                  - "logs:CreateLogGroup"
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
                 Resource:
                   - arn:aws:logs:*:*:*
   DNSRecord:
     Condition: CreateRoute53Records
-    Type: "AWS::Route53::RecordSet"
+    Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneId: !Ref Route53HostedZoneID
       Comment: DNS record pointing to load balancer for 1Password SCIM Bridge
@@ -428,7 +436,7 @@ Resources:
         DNSName: !GetAtt LoadBalancer.DNSName
         HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
   TLSCertificate:
-    Type: "AWS::CertificateManager::Certificate"
+    Type: AWS::CertificateManager::Certificate
     Properties:
       DomainName: !Ref DomainName
       ValidationMethod: DNS
@@ -436,9 +444,9 @@ Resources:
         - CreateRoute53Records
         - - DomainName: !Ref DomainName
             HostedZoneId: !Ref Route53HostedZoneID
-        - !Ref "AWS::NoValue"
+        - !Ref AWS::NoValue
   TaskRole:
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -448,7 +456,7 @@ Resources:
               Service:
                 - ecs-tasks.amazonaws.com
             Action:
-              - "sts:AssumeRole"
+              - sts:AssumeRole
       Path: /
       Policies:
         - PolicyName: cloudwatch_logging
@@ -457,9 +465,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - "logs:CreateLogGroup"
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
                 Resource: "*"
         - PolicyName: vpc_access
           PolicyDocument:
@@ -467,69 +475,83 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - "ec2:CreateNetworkInterface"
-                  - "ec2:DescribeNetworkInterfaces"
-                  - "ec2:DeleteNetworkInterface"
+                  - ec2:CreateNetworkInterface
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:DeleteNetworkInterface
                 Resource: "*"
-
+        - PolicyName: secrets_manager_policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref scimsessionSecret
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceCredentialsSecret
+                    - !Ref AWS::NoValue
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceSettingsSecret
+                    - !Ref AWS::NoValue
   VPC:
     Condition: CreateVPC
-    Type: "AWS::EC2::VPC"
+    Type: AWS::EC2::VPC
     Properties:
       CidrBlock: !Ref VPCCIDR
       EnableDnsHostnames: true
       EnableDnsSupport: true
   PublicSubnet1:
-    Type: "AWS::EC2::Subnet"
+    Type: AWS::EC2::Subnet
     Condition: CreateVPC
     Properties:
       AvailabilityZone:
-        "Fn::Select":
+        Fn::Select:
           - 0
-          - "Fn::GetAZs":
-              Ref: "AWS::Region"
+          - Fn::GetAZs: !Ref AWS::Region
       VpcId: !Ref VPC
       CidrBlock:
-        "Fn::Select":
+        Fn::Select:
           - 0
-          - "Fn::Cidr":
+          - Fn::Cidr:
               - !GetAtt VPC.CidrBlock
               - 16
               - 12
   PublicSubnet2:
-    Type: "AWS::EC2::Subnet"
+    Type: AWS::EC2::Subnet
     Condition: CreateVPC
     Properties:
       AvailabilityZone:
-        "Fn::Select":
+        Fn::Select:
           - 1
-          - "Fn::GetAZs":
-              Ref: "AWS::Region"
+          - Fn::GetAZs: !Ref AWS::Region
       VpcId: !Ref VPC
       CidrBlock:
-        "Fn::Select":
+        Fn::Select:
           - 1
-          - "Fn::Cidr":
+          - Fn::Cidr:
               - !GetAtt VPC.CidrBlock
               - 16
               - 12
   InternetGateway:
     Condition: CreateVPC
-    Type: "AWS::EC2::InternetGateway"
+    Type: AWS::EC2::InternetGateway
   GatewayAttachment:
     Condition: CreateVPC
-    Type: "AWS::EC2::VPCGatewayAttachment"
+    Type: AWS::EC2::VPCGatewayAttachment
     Properties:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
   RouteTable:
     Condition: CreateVPC
-    Type: "AWS::EC2::RouteTable"
+    Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
   Route:
     Condition: CreateVPC
-    Type: "AWS::EC2::Route"
+    Type: AWS::EC2::Route
     DependsOn: GatewayAttachment
     Properties:
       RouteTableId: !Ref RouteTable
@@ -537,13 +559,13 @@ Resources:
       GatewayId: !Ref InternetGateway
   PublicSubnet1RouteTableAssociation:
     Condition: CreateVPC
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref PublicSubnet1
       RouteTableId: !Ref RouteTable
   PublicSubnet2RouteTableAssociation:
     Condition: CreateVPC
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref PublicSubnet2
       RouteTableId: !Ref RouteTable
@@ -553,15 +575,15 @@ Outputs:
     Description: >-
       Name of a DNS record to point to the load balancer. Use with CNAMEValue to create a CNAME record in your DNS
       provider.
-    Value: !Sub "${DomainName}."
+    Value: !Sub ${DomainName}.
   CNAMEValue:
     Condition: OutputDNSRecordContent
     Description: >-
       Value of a DNS record to point to the load balancer. Use with CNAMEName to create a public CNAME record in your
       DNS provider.
-    Value: !Sub "${LoadBalancer.DNSName}."
+    Value: !Sub ${LoadBalancer.DNSName}.
   SCIMBridgeURL:
     Description: >-
       The URL for your SCIM bridge. Use this and your bearer token to connect
       your identity provider to 1Password.
-    Value: !Sub "https://${DomainName}"
+    Value: !Sub https://${DomainName}

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -529,6 +529,7 @@ Resources:
       Protocol: HTTPS
       Certificates:
         - CertificateArn: !Ref TLSCertificate
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
 
   TaskRole:
     Type: "AWS::IAM::Role"

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -41,9 +41,9 @@ Parameters:
     Default: 10.0.0.0/16
     Description: A CIDR block for the VPC to be created.
   Route53HostedZoneID:
-    Type: "AWS::Route53::HostedZone::Id"
-    Description: >-
-      The Route 53 hosted zone in which to create DNS records for ACM validation and the ALB endpoint.
+    Type: String
+    Default: ""
+    Description: "(Optional) Route 53 Hosted Zone ID for DNS validation. Leave blank if using external DNS provider."
   ProvisioningVolume:
     Type: String
     Description: >-
@@ -57,7 +57,7 @@ Parameters:
     ConstraintDescription: must be base, high, or very-high
   DomainName:
     Type: String
-    Default: scim.example.com
+    Default: scim.doucette.io
     Description: >-
       A fully qualified domain name for your SCIM bridge that is in the domain of the selected Route 53 hosted zone
       where the record will be created.
@@ -127,6 +127,7 @@ Mappings:
       Redis: 512
       Task: 4096
 Conditions:
+  CreateRoute53Records: !Not [!Equals [!Ref Route53HostedZoneID, ""]]
   UsingGoogleWorkspace: !Not
     - !Or
       - !Equals [!Ref WorkspaceCredentials, ""]
@@ -469,6 +470,7 @@ Resources:
                   - "logs:PutLogEvents"
                 Resource: "*"
   DNSRecord:
+    Condition: CreateRoute53Records
     Type: "AWS::Route53::RecordSet"
     Properties:
       HostedZoneId: !Ref Route53HostedZoneID
@@ -481,11 +483,14 @@ Resources:
   TLSCertificate:
     Type: "AWS::CertificateManager::Certificate"
     Properties:
-      DomainName: !Ref DNSRecord
-      ValidationMethod: DNS
-      DomainValidationOptions:
-        - DomainName: !Ref DNSRecord
-          HostedZoneId: !Ref Route53HostedZoneID
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS  # Always use DNS validation
+      DomainValidationOptions: !If
+        - CreateRoute53Records
+        - 
+          - DomainName: !Ref DomainName
+            HostedZoneId: !Ref Route53HostedZoneID
+        - !Ref "AWS::NoValue"  # No HostedZoneId for external DNS, you will need to manually create CNAME
   TaskRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -602,4 +607,7 @@ Outputs:
     Description: >-
       The URL for your SCIM bridge. Use this and your bearer token to connect
       your identity provider to 1Password.
-    Value: !Sub "https://${DNSRecord}"
+    Value: !If
+      - CreateRoute53Records
+      - !Sub "https://${DNSRecord}"
+      - !Sub "https://${DomainName}"

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -411,18 +411,6 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  # These were included in the previous version of the template, but may not be needed.
-                  # - "ec2:AuthorizeSecurityGroupIngress"
-                  # - "ec2:Describe*"
-                  # - "ecr:BatchCheckLayerAvailability"
-                  # - "ecr:BatchGetImage"
-                  # - "ecr:GetAuthorizationToken"
-                  # - "ecr:GetDownloadUrlForLayer"
-                  # - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-                  # - "elasticloadbalancing:DeregisterTargets"
-                  # - "elasticloadbalancing:Describe*"
-                  # - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
-                  # - "elasticloadbalancing:RegisterTargets"
                   - "logs:CreateLogGroup"
                   - "logs:CreateLogStream"
                   - "logs:PutLogEvents"
@@ -482,24 +470,8 @@ Resources:
                   - "ec2:CreateNetworkInterface"
                   - "ec2:DescribeNetworkInterfaces"
                   - "ec2:DeleteNetworkInterface"
-                  # These may not be necessary
-                  # - "ec2:Describe*"
-                  # - "ec2:AuthorizeSecurityGroupIngress"
                 Resource: "*"
-        - PolicyName: task_execution_role_policy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "ecr:GetAuthorizationToken"
-                  - "ecr:BatchCheckLayerAvailability"
-                  - "ecr:GetDownloadUrlForLayer"
-                  - "ecr:BatchGetImage"
-                  # These may not be necessary
-                  # - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-                  # - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
-                Resource: "*"
+  
   VPC:
     Condition: CreateVPC
     Type: "AWS::EC2::VPC"


### PR DESCRIPTION
A stack that is created using our current CloudFormation template example includes a VPC with public subnets and associated resources and DNS records using Route 53. This PR includes changes to enhance the template, enabling customers to:
- select an existing VPC and public subnets
- exclude the DNS records from the stack
 
Documentation has been updated accordingly, and includes additional changes to align with our other deployment examples.

Additional enhancements:

- updated TLS policy to enforce TLS 1.3
- refactored and simplified Redis configuration
- stripped redundant policy actions
- specified ARM64 platform to reduce expected cost
- stores unencoded values in AWS secrets
- [writes secrets to volume instead of env var values](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html#security-secrets-management-recommendations-mount-secret-volumes)
- reconfigured for zero-downtime rolling updates

Testing criteria:
- update an existing stack deployed using the existing template and no other changes
- create a new stack, specifying an existing VPC and subnets
- create a new stack without specifying a Route 53 hosted zone