### PR TITLE
Typo in test curl commands for Docker and K8 deployment examples

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -77,7 +77,7 @@ You can also check the status of your SCIM bridge with a bearer token authentica
    ```sh
    # The below commmand includes a prepended space so that the bearer token is not saved to your terminal history
     export OP_SCIM_TOKEN="mF_9.B5f-4.1JqM"
-   export OP_SCIM_BRIDGE_URL="https:/op-scim-bridge.example.com"
+   export OP_SCIM_BRIDGE_URL="https://op-scim-bridge.example.com"
    ```
 
 2. Use the environment variables in your request. For example, using `curl`:

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -103,7 +103,7 @@ Use your SCIM bridge URL to test the connection and view status information. For
 ```sh
 curl --silent --show-error --request GET --header "Accept: application/json" \
   --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
-  https:/scim.example.com/health
+  https://scim.example.com/health
 ```
 
 Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM bridge URL.


### PR DESCRIPTION
Two small typos picked up through Customer Experience regarding our example URL provided in the test `curl` command.