### PR TITLE
Remove AKS reference

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,5 +1,9 @@
 # Deploy 1Password SCIM Bridge on Kubernetes
 
+> **Note**
+>
+> If you use Azure Kubernetes Service, learn how to [deploy the SCIM bridge there](https://support.1password.com/cs/scim-deploy-azure-kubernetes/).
+
 _Learn how to deploy 1Password SCIM Bridge on a Kubernetes cluster._
 
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -2,9 +2,6 @@
 
 _Learn how to deploy 1Password SCIM Bridge on a Kubernetes cluster._
 
-> **Note**
->
-> If you use Azure Kubernetes Service, learn how to [deploy the SCIM bridge there](https://support.1password.com/scim-deploy-azure/).
 
 ## Before you begin
 


### PR DESCRIPTION
Now that `@scim-deploy-azure` points to ACA, the callout here doesn't make sense.