### PR TITLE
Introduce AWS CloudFormation with API Gateway deployment example

### DIFF
--- a/beta/aws-ecs-apigateway-cfn/README.md
+++ b/beta/aws-ecs-apigateway-cfn/README.md
@@ -11,8 +11,8 @@ This template deploys 1Password SCIM Bridge and the required Redis cache as Farg
 ## Prerequisites
 
 - A 1Password account with an active 1Password Business subscription or trial
-> [!TIP]
-> Try 1Password Business **free** for 14 days: <https://start.1password.com/sign-up/business>
+  > [!TIP]
+  > Try 1Password Business **free** for 14 days: <https://start.1password.com/sign-up/business>
 - An AWS account with the permissions and available quota to create and manage the described resources
 
 ## Before you begin
@@ -26,7 +26,7 @@ Consult the [Preparation Guide](/PREPARATION.md) in this repository. Since this 
 
 ## Step 1: Upload the stack template file
 
-1. Sign in to AWS and [create a stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create).
+1. Sign in to AWS and [create a stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create) (if you don't want to click that link, in the CloudFormation console, choose **Create stack** and then **With new resources (standard)**).
 2. In the **Prerequisite - Prepare template** section, select **Choose an existing template**.
 3. In the **Specify template** section, choose **Upload a template file**.
 4. Click **↑ Choose file** and upload the [`op-scim-bridge.yaml`](./op-scim-bridge.yaml) template file from your computer. Click **Next**.

--- a/beta/aws-ecs-apigateway-cfn/README.md
+++ b/beta/aws-ecs-apigateway-cfn/README.md
@@ -1,0 +1,132 @@
+# Deploy 1Password SCIM Bridge with AWS CloudFormation (API Gateway)
+
+_Learn how to deploy 1Password SCIM Bridge using [AWS CloudFormation](https://docs.aws.amazon.com/cloudformation/index.html)._
+
+This guide can be used to deploy 1Password SCIM Bridge as a [stack](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-whatis-concepts.html#cfn-concepts-stacks) using the [AWS CloudFormation console](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console.html).
+
+The included [AWS CloudFormation template](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stack-templates-overview.html) is a working example that is suitable for use in a production environment. Some common customizations are included for convenience, but it is intentionally minimal for simplicity, to allow any identity provider to connect to its public endpoint, and to facilitate its use as a base for a custom deployment that meets your specific requirements.
+
+This template deploys 1Password SCIM Bridge and the required Redis cache as Fargate tasks within ECS services integrated with AWS Cloud Map for service discovery. A VPC with at least two public subnets is required; these will be created automatically if not provided. Credentials are stored in and provided by AWS Secrets Manager. A public TLS endpoint is provided by Amazon API Gateway. Minimal IAM roles, policy, and security group resources are included for access control and principle of least privelege.
+
+## Prerequisites
+
+- A 1Password account with an active 1Password Business subscription or trial
+> [!TIP]
+> Try 1Password Business **free** for 14 days: <https://start.1password.com/sign-up/business>
+- An AWS account with the permissions and available quota to create and manage the described resources
+
+## Before you begin
+
+Consult the [Preparation Guide](/PREPARATION.md) in this repository. Since this CloudFormation template will create all necessary resources, it does not use the CertificateManager component to acquire and manage a TLS certificate. API Gateway provides the TLS endpoint. No DNS records are required.
+
+1. Download the [`op-scim-bridge.yaml`](./op-scim-bridge.yaml) template file from this repository to your computer.
+2. Follow the steps in [Automate provisioning in 1Password Business using SCIM](https://support.1password.com/scim/#step-1-set-up-and-deploy-1password-scim-bridge) to generate credentials for your SCIM bridge.
+3. Save the `scimsession` credentials file and the associated bearer token as items in your 1Password account.
+4. Download the `scimsession` file to your computer.
+
+## Step 1: Upload the stack template file
+
+1. Sign in to AWS and [create a stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create).
+2. In the **Prerequisite - Prepare template** section, select **Choose an existing template**.
+3. In the **Specify template** section, choose **Upload a template file**.
+4. Click **↑ Choose file** and upload the [`op-scim-bridge.yaml`](./op-scim-bridge.yaml) template file from your computer. Click **Next**.
+
+## Step 2: Specify stack details
+
+1. Type `op-scim-bridge` in the **Stack name** field, or choose your own stack name. CloudFormation will use the stack name (or a truncated version where needed) as a prefix when naming the created AWS resources.
+2. To use an existing VPC, input its ID in the **VPC ID** field. The stack will create a new VPC with two public subnets and associated resources if this field is empty.
+3. A CIDR block must be specified when creating a VPC. If creating a VPC with the stack, use the default value provided or specify your own in the **VPC CIDR** field. This field is ignored when specifying a VPC ID.
+4. If specifying an existing VPC, input a comma-separated list of IDs for at least two public subnet IDs in the **Public subnets** field. The subnets must span at least two Avilability Zones. This field is required when using an existing VPC and ignored otherwise.
+5. If you are provisioning more than 1,000 users to 1Password, choose the appropriate value for **Provisioning volume**. Choose `high` for up to 5,000 users, or `very-high` for more than 5,000.
+6. Open the `scimsession` file from your working directory in your favourite text editor. Select all text in the file and copy it to your clipboard. Paste the contents into the `scimession` field (input will be masked).
+7. **If Google Workspace is your identity provider**, [create a service account, key, and API client](https://support.1password.com/scim-google-workspace/#step-1-create-a-google-service-account-key-and-api-client). Save the Google Workspace service account key file to your computer, open the file in a text editor, select all text in the file, and copy it to your clipboard. In the **Workspace configuration** section:
+   - Paste the contents of the key file (from your clipboard) into the **Service account key** field (the input will be masked).
+   - Input the email address for a Google Workspace administrator to use with the service account in the **Actor** field.
+8. Click **Next**.
+
+## Step 3: Configure stack options
+
+1. Click **Add new tag** to add any that you require to all supported resources in the stack.
+2. Review the options. Use the provided defaults or your own options as required or preferred. Click **Next**.
+
+## Step 4: Review and create the stack
+
+1. Review the details and edit as necessary.
+2. Select **I acknowledge that AWS CloudFormation might create IAM resources**.
+3. Click **Submit** to begin deploying the stack.
+
+The console will display the stack status as `ℹ️ CREATE_IN_PROGRESS` during the deployment. The stack is expected to take a few minutes to create (~2–3 minutes when this document was written).
+
+## Step 5: Test your SCIM bridge
+
+Your **SCIM bridge URL** is displayed in the **Outputs** tab of the CloudFormation console. Click the link to access the web interface for your SCIM bridge. Sign in using your bearer token to test the connection, view status information, and download logs.
+
+To test the connection and view the same status information in your terminal, you can send an authenticated request to the `/health` endpoint of your SCIM bridge. Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` with your SCIM bridge URL.
+
+```sh
+curl --silent --show-error --request GET --header "Accept: application/json" \
+  --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
+  https://scim.example.com/health
+```
+
+> [!TIP]
+> If you saved your bearer token as an item in your 1Password account, you can [use 1Password CLI to supply the bearer token](https://developer.1password.com/docs/cli/secrets-scripts#option-2-use-op-read-to-read-secrets) instead. For example:
+>
+> ```sh
+> # ...
+>   --header "Authorization: Bearer $(op read "op://Employee/bearer token/credential")"
+> # ...
+> ```
+
+<details>
+<summary>Example JSON response:</summary>
+
+```json
+{
+  "build": "209031",
+  "version": "2.9.9",
+  "reports": [
+    {
+      "source": "ConfirmationWatcher",
+      "time": "2025-03-12T14:06:09Z",
+      "expires": "2025-03-12T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "RedisCache",
+      "time": "2025-03-12T14:06:09Z",
+      "expires": "2025-03-12T14:16:09Z",
+      "state": "healthy"
+    },
+    {
+      "source": "SCIMServer",
+      "time": "2025-03-12T14:06:56Z",
+      "expires": "2025-03-12T14:16:56Z",
+      "state": "healthy"
+    },
+    {
+      "source": "StartProvisionWatcher",
+      "time": "2025-03-12T14:06:09Z",
+      "expires": "2025-03-12T14:16:09Z",
+      "state": "healthy"
+    }
+  ],
+  "retrievedAt": "2025-03-12T14:06:56Z"
+}
+```
+
+</details>
+
+## Step 6: Connect your identity provider
+
+Use your SCIM bridge URL and bearer token to [connect your identity provider to 1Password SCIM Bridge](https://support.1password.com/scim/#step-3-connect-your-identity-provider).
+
+If you are integrating with Google Workspace, sign in to your SCIM bridge URL using your bearer token and [set up provisioning to 1Password](https://support.1password.com/scim-google-workspace/#22-set-up-provisioning-to-1password).
+
+## Maintenance
+
+A quarterly review and maintenance schedule is recommended.
+
+### Update your SCIM bridge
+
+To update to the latest version of 1Password SCIM Bridge, update your stack with a new value for the `SCIMBridgeVersion` parameter. Use the latest template from this repository ([`op-scim-bridge.yaml`](./op-scim-bridge.yaml)) and update the value of "1Password SCIM Bridge version" (the `SCIMBridgeVersion` parameter) to the latest version. Use the existing values for everything else.

--- a/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
@@ -1,0 +1,567 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Deploys 1Password SCIM Bridge on AWS Fargate in an Amazon ECS cluster with Amazon API Gateway and AWS Cloud Map,
+  Includes AWS secret, IAM role and policy, security group resources. Optionally creates a VPc and related resources.
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Parameters:
+          - VPCID
+          - VPCCIDR
+          - PublicSubnets
+          - ProvisioningVolume
+          - SCIMBridgeVersion
+          - scimsession
+      - Label:
+          default: Workspace configuration (only for customers integrating with Google Workspace)
+        Parameters:
+          - WorkspaceCredentials
+          - WorkspaceActor
+    ParameterLabels:
+      VPCID:
+        default: VPC ID
+      VPCCIDR:
+        default: VPC CIDR
+      PublicSubnets:
+        default: Public subnets
+      ProvisioningVolume:
+        default: Provisioning volume
+      SCIMBridgeVersion:
+        default: 1Password SCIM Bridge version
+      WorkspaceCredentials:
+        default: Service account key
+      WorkspaceActor:
+        default: Actor
+Parameters:
+  VPCID:
+    Type: String
+    Description: >-
+      (Optional) ID of an existing VPC to use for your SCIM bridge. If empty, a new VPC and two public subnets will be
+      created.
+  VPCCIDR:
+    Type: String
+    Default: 10.0.0.0/16
+    Description: A CIDR block for the VPC. Required if VPCID is empty; ignored if specifying a VPCID.
+  PublicSubnets:
+    Type: CommaDelimitedList
+    Description: (Optional) A comma-separated list of two or more public subnets in the specified VPC.
+    ConstraintDescription: >-
+      must be a list of at least two existing subnets associated a unique availability zone in the specified VPC
+  ProvisioningVolume:
+    Type: String
+    Description: >-
+      The expected volume of provisioning activity. Use base for provisioning less than 1,000 users, high for up to
+      5,000 users, or very-high for more than 5,000 users.
+    Default: base
+    AllowedValues:
+      - base
+      - high
+      - very-high
+    ConstraintDescription: must be base, high, or very-high
+  scimsession:
+    Type: String
+    Description: >-
+      The plain text contents of the scimsession file created during the automated user provisioning setup in your
+      1Password account.
+    MinLength: 1
+    ConstraintDescription: must not be empty
+    NoEcho: true
+  SCIMBridgeVersion:
+    Type: String
+    Default: v2.9.7
+    Description: >-
+      The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
+  WorkspaceCredentials:
+    Type: String
+    Default: ""
+    Description: >-
+      The plain text contents of the key file associated with the service account for Google Workspace.
+    NoEcho: true
+  WorkspaceActor:
+    Type: String
+    Default: ""
+    Description: >-
+      The email address of the Google Workspace administrator that the service account is acting on behalf of.
+Rules:
+  ValidateWorkspaceConfig:
+    RuleCondition: !Not
+      - Fn::EachMemberEquals:
+          - - !Ref WorkspaceCredentials
+            - !Ref WorkspaceActor
+          - ""
+    Assertions:
+      - Assert: !Not [!Equals [!Ref WorkspaceCredentials, ""]]
+        AssertDescription: >-
+          The service account key is required to connect to Google Workspace.
+      - Assert: !Not [!Equals [!Ref WorkspaceActor, ""]]
+        AssertDescription: >-
+          The actor email is required to connect to Google Workspace.
+Mappings:
+  SCIMBridgeResources:
+    base:
+      Cpu: 256
+      Memory: 512
+    high:
+      Cpu: 512
+      Memory: 1024
+    very-high:
+      Cpu: 1024
+      Memory: 1024
+Conditions:
+  CreateVPC: !Equals [!Ref VPCID, ""]
+  UsingGoogleWorkspace: !Not
+    - !Or
+      - !Equals [!Ref WorkspaceCredentials, ""]
+      - !Equals [!Ref WorkspaceActor, ""]
+Resources:
+  scimsessionSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      SecretString: !Ref scimsession
+  WorkspaceCredentialsSecret:
+    Type: AWS::SecretsManager::Secret
+    Condition: UsingGoogleWorkspace
+    Properties:
+      SecretString: !Ref WorkspaceCredentials
+  WorkspaceSettingsSecret:
+    Type: AWS::SecretsManager::Secret
+    Condition: UsingGoogleWorkspace
+    Properties:
+      SecretString: !Sub |-
+        {
+          "actor":"${WorkspaceActor}",
+          "bridgeAddress":"${ApiGateway.ApiEndpoint}"
+        }
+  VPC:
+    Condition: CreateVPC
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VPCCIDR
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Condition: CreateVPC
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: !Ref AWS::Region
+      VpcId: !Ref VPC
+      CidrBlock:
+        Fn::Select:
+          - 0
+          - Fn::Cidr:
+              - !GetAtt VPC.CidrBlock
+              - 16
+              - 12
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Condition: CreateVPC
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: !Ref AWS::Region
+      VpcId: !Ref VPC
+      CidrBlock:
+        Fn::Select:
+          - 1
+          - Fn::Cidr:
+              - !GetAtt VPC.CidrBlock
+              - 16
+              - 12
+  InternetGateway:
+    Condition: CreateVPC
+    Type: AWS::EC2::InternetGateway
+  GatewayAttachment:
+    Condition: CreateVPC
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  RouteTable:
+    Condition: CreateVPC
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+  Route:
+    Condition: CreateVPC
+    Type: AWS::EC2::Route
+    DependsOn: GatewayAttachment
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  PublicSubnet1RouteTableAssociation:
+    Condition: CreateVPC
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet1
+      RouteTableId: !Ref RouteTable
+  PublicSubnet2RouteTableAssociation:
+    Condition: CreateVPC
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref RouteTable
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ECSLogs
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - arn:aws:logs:*:*:*
+  SCIMBridgeTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: SecretAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref scimsessionSecret
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceCredentialsSecret
+                    - !Ref AWS::NoValue
+                  - !If
+                    - UsingGoogleWorkspace
+                    - !Ref WorkspaceSettingsSecret
+                    - !Ref AWS::NoValue
+  ServiceDiscoveryNamespace:
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Properties:
+      Description: AWS Cloud Map private DNS namespace for 1Password SCIM Bridge.
+      Vpc: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+      Name: op-scim-bridge
+  RedisService:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      DnsConfig:
+        DnsRecords:
+          - TTL: 60
+            Type: A
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: redis
+      NamespaceId: !Ref ServiceDiscoveryNamespace
+  SCIMBridgeService:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      DnsConfig:
+        DnsRecords:
+          - TTL: 60
+            Type: SRV
+      Name: scim
+      NamespaceId: !Ref ServiceDiscoveryNamespace
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    DependsOn: ExecutionRole
+    Properties:
+      CapacityProviders:
+        - FARGATE
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: FARGATE
+          Weight: 1
+  RedisTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: op-scim-redis
+      RequiresCompatibilities:
+        - FARGATE
+      NetworkMode: awsvpc
+      Cpu: 256
+      Memory: 512
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
+      ContainerDefinitions:
+        - Name: redis
+          Image: redis
+          User: redis:redis
+          Command:
+            - --maxmemory 256mb
+            - --maxmemory-policy volatile-lru
+            - --save ""
+          PortMappings: [ContainerPort: 6379]
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - redis-cli ping | grep PONG
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: ecs/op-scim-bridge
+  SCIMBridgeTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: op-scim-bridge
+      RequiresCompatibilities:
+        - FARGATE
+      NetworkMode: awsvpc
+      Cpu: !FindInMap
+        - SCIMBridgeResources
+        - !Ref ProvisioningVolume
+        - Cpu
+      Memory: !FindInMap
+        - SCIMBridgeResources
+        - !Ref ProvisioningVolume
+        - Memory
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !Ref SCIMBridgeTaskRole
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
+      Volumes:
+        - Name: secrets
+      ContainerDefinitions:
+        - Name: mount-secrets
+          Essential: false
+          Image: amazon/aws-cli
+          MountPoints:
+            - ContainerPath: /aws
+              SourceVolume: secrets
+          Environment:
+            - Name: SCIMSESSION_ARN
+              Value: !Ref scimsessionSecret
+            - !If
+              - UsingGoogleWorkspace
+              - Name: WORKSPACE_CREDENTIALS_ARN
+                Value: !Ref WorkspaceCredentialsSecret
+              - !Ref AWS::NoValue
+            - !If
+              - UsingGoogleWorkspace
+              - Name: WORKSPACE_SETTINGS_ARN
+                Value: !Ref WorkspaceSettingsSecret
+              - !Ref AWS::NoValue
+          EntryPoint:
+            - /bin/bash
+            - -c
+          Command:
+            - !Join
+              - " "
+              - - >-
+                  aws secretsmanager get-secret-value
+                  --secret-id $SCIMSESSION_ARN --query SecretString --output text
+                  > scimsession
+                - !If
+                  - UsingGoogleWorkspace
+                  - >-
+                    && aws secretsmanager get-secret-value
+                    --secret-id $WORKSPACE_CREDENTIALS_ARN --query SecretString --output text
+                    > workspace-credentials.json
+                    && aws secretsmanager get-secret-value
+                    --secret-id $WORKSPACE_SETTINGS_ARN --query SecretString --output text
+                    > workspace-settings.json
+                  - !Ref AWS::NoValue
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: ecs/op-scim-bridge
+        - Name: scim
+          Image: !Sub 1password/scim:${SCIMBridgeVersion}
+          User: opuser:opuser
+          PortMappings: [ContainerPort: 3002]
+          DependsOn:
+            - ContainerName: mount-secrets
+              Condition: SUCCESS
+          MountPoints:
+            - ContainerPath: /home/opuser/.op
+              SourceVolume: secrets
+          Environment:
+            - Name: OP_REDIS_URL
+              Value: !Sub redis://${RedisService.Name}.op-scim-bridge:6379
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: ecs/op-scim
+  RedisECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref ECSCluster
+      PropagateTags: SERVICE
+      TaskDefinition: !Ref RedisTaskDefinition
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          Subnets: !If
+            - CreateVPC
+            - [!Ref PublicSubnet1, !Ref PublicSubnet2]
+            - !Ref PublicSubnets
+          SecurityGroups:
+            - !Ref RedisSecurityGroup
+      ServiceRegistries:
+        - ContainerName: redis
+          RegistryArn: !GetAtt RedisService.Arn
+  SCIMBridgeECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref ECSCluster
+      PropagateTags: SERVICE
+      TaskDefinition: !Ref SCIMBridgeTaskDefinition
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          Subnets: !If
+            - CreateVPC
+            - [!Ref PublicSubnet1, !Ref PublicSubnet2]
+            - !Ref PublicSubnets
+          SecurityGroups:
+            - !Ref SCIMBridgeSecurityGroup
+      ServiceRegistries:
+        - ContainerName: scim
+          ContainerPort: 3002
+          RegistryArn: !GetAtt SCIMBridgeService.Arn
+  ApiGatewaySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: API Gateway traffic for 1Password SCIM Bridge.
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+  SCIMBridgeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: ECS Service traffic for 1Password SCIM Bridge.
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+  RedisSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Redis traffic for 1Password SCIM Bridge.
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+  ApiGatewayEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref ApiGatewaySecurityGroup
+      IpProtocol: tcp
+      FromPort: 3002
+      ToPort: 3002
+      DestinationSecurityGroupId: !Ref SCIMBridgeSecurityGroup
+  SCIMBridgeIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref SCIMBridgeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 3002
+      ToPort: 3002
+      SourceSecurityGroupId: !Ref ApiGatewaySecurityGroup
+  SCIMBridgeRedisEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref SCIMBridgeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 6379
+      ToPort: 6379
+      DestinationSecurityGroupId: !Ref RedisSecurityGroup
+  SCIMBridgePublicEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref SCIMBridgeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: 0.0.0.0/0
+  RedisIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref RedisSecurityGroup
+      Description: Redis traffic from SCIM Bridge service.
+      IpProtocol: tcp
+      FromPort: 6379
+      ToPort: 6379
+      SourceSecurityGroupId: !Ref SCIMBridgeSecurityGroup
+  RedisEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      Description: HTTPS to Docker Hub.
+      GroupId: !Ref RedisSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: 0.0.0.0/0
+  VpcLink:
+    Type: AWS::ApiGatewayV2::VpcLink
+    Properties:
+      Name: op-scim-bridge
+      SecurityGroupIds:
+        - !Ref ApiGatewaySecurityGroup
+      SubnetIds: !If
+        - CreateVPC
+        - [!Ref PublicSubnet1, !Ref PublicSubnet2]
+        - !Ref PublicSubnets
+  ApiGateway:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: op-scim-bridge
+      ProtocolType: HTTP
+  ApiGatewayRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: $default
+      AuthorizationType: NONE
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ApiGatewayIntegration
+  ApiGatewayIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref ApiGateway
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: ANY
+      ConnectionType: VPC_LINK
+      ConnectionId: !Ref VpcLink
+      IntegrationUri: !GetAtt SCIMBridgeService.Arn
+      PayloadFormatVersion: 1.0
+  ApiGatewayStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      StageName: $default
+      ApiId: !Ref ApiGateway
+      AutoDeploy: true
+Outputs:
+  SCIMBridgeURL:
+    Description: >-
+      The URL for your SCIM bridge. Use this and your bearer token to connect your identity provider to 1Password.
+    Value: !GetAtt ApiGateway.ApiEndpoint

--- a/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Deploys 1Password SCIM Bridge on AWS Fargate in an Amazon ECS cluster with Amazon API Gateway and AWS Cloud Map,
-  Includes AWS secret, IAM role and policy, security group resources. Optionally creates a VPc and related resources.
+  Includes AWS secret, IAM role and policy, security group resources. Optionally creates a VPC and related resources.
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -68,7 +68,7 @@ Parameters:
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: v2.9.7
+    Default: v2.9.9
     Description: >-
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
   WorkspaceCredentials:
@@ -81,7 +81,7 @@ Parameters:
     Type: String
     Default: ""
     Description: >-
-      The email address of the Google Workspace administrator that the service account is acting on behalf of.
+      The email address of a Google Workspace administrator that the service account authenticates as.
 Rules:
   ValidateWorkspaceConfig:
     RuleCondition: !Not
@@ -265,7 +265,7 @@ Resources:
     Properties:
       Description: AWS Cloud Map private DNS namespace for 1Password SCIM Bridge.
       Vpc: !If [CreateVPC, !Ref VPC, !Ref VPCID]
-      Name: op-scim-bridge
+      Name: 1password
   RedisService:
     Type: AWS::ServiceDiscovery::Service
     Properties:
@@ -326,7 +326,7 @@ Resources:
             Options:
               awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: ecs/op-scim-bridge
+              awslogs-stream-prefix: ecs/op-scim
   SCIMBridgeTaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -394,7 +394,7 @@ Resources:
             Options:
               awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: ecs/op-scim-bridge
+              awslogs-stream-prefix: ecs/op-scim
         - Name: scim
           Image: !Sub 1password/scim:${SCIMBridgeVersion}
           User: opuser:opuser
@@ -407,7 +407,7 @@ Resources:
               SourceVolume: secrets
           Environment:
             - Name: OP_REDIS_URL
-              Value: !Sub redis://${RedisService.Name}.op-scim-bridge:6379
+              Value: !Sub redis://${RedisService.Name}.1password:6379
           LogConfiguration:
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
This PR adds a new beta deployment example for AWS using CloudFormation.

This repository already includes examples for AWS that also use Amazon Elastic Container Service; this example uses API Gateway to provide a TLS endpoint instead of a discrete load balancer for a faster time-to-deploy, fewer managed components, and much lower cost.

ECS services are integrated with AWS Cloud Map for service discovery. A VPC with at least two public subnets is required and optionally created and managed by the stack. Credentials are stored in and provided by AWS Secrets Manager. Minimal IAM roles, policy, and security group resources are included for access control and principle of least privilege.