### PR TITLE
Update AWS ALB SSL policy to `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -270,7 +270,7 @@ resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_alb.op_scim_bridge.arn
   port              = 443
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
 
   certificate_arn = !var.wildcard_cert ? (
     var.using_route53 ?

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -399,7 +399,7 @@ Resources:
       Protocol: HTTPS
       Certificates:
         - CertificateArn: !Ref TLSCertificate
-      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-Res-2021-06
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
Change the SSL policy used for AWS ALBs from `ELBSecurityPolicy-TLS13-1-2-2021-06` to `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`.

This removes the following (insecure) cipher suites:
- ECDHE-ECDSA-AES128-SHA256
- ECDHE-RSA-AES128-SHA256
- ECDHE-ECDSA-AES256-SHA384
- ECDHE-RSA-AES256-SHA384

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#tls-security-policies