### PR TITLE
fix(NO-REF): fixed problems on certificate retrival and landing zone …

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -15,7 +15,6 @@ provider "aws" {
 
 locals {
   name_prefix = var.name_prefix != "" ? var.name_prefix : "op-scim-bridge"
-  domain      = join(".", slice(split(".", var.domain_name), 1, length(split(".", var.domain_name))))
   tags = merge(var.tags, {
     application = "1Password SCIM Bridge",
     version     = trimprefix(jsondecode(file("${path.module}/task-definitions/scim.json"))[0].image, "1password/scim:v")
@@ -100,14 +99,13 @@ data "aws_iam_policy_document" "scimsession" {
 
 data "aws_acm_certificate" "wildcard_cert" {
   count = !var.wildcard_cert ? 0 : 1
-
-  domain = "*.${local.domain}"
+  domain = var.domain_name
 }
 
 data "aws_route53_zone" "zone" {
   count = var.using_route53 ? 1 : 0
 
-  name         = local.domain
+  name         = "${var.domain_name}."
   private_zone = false
 }
 


### PR DESCRIPTION
## Feedback on SCIM Bridge Deployment and Certificate Retrieval

Hello,

Yesterday I deployed the SCIM bridge for my company on AWS and encountered a couple of issues that I was able to resolve, which I’d like to share in case they’re helpful.

### 1. Landing Zone Retrieval  
I noticed that the landing zone name requires a **trailing dot** after the URL. Without it, the system fails to retrieve the necessary information. Adding the dot resolved the issue.

### 2. Wildcard Certificate Retrieval  
I’m using an ACM certificate associated with the following domains:
- `scim-example.com`
- `*.scim-example.com`  

To retrieve this certificate programmatically, it’s important to specify the **primary domain name** (`scim-example.com`). Using only the wildcard domain causes the retrieval to fail.

---

I hope this information proves useful to others deploying the SCIM bridge.

Best regards,  
**Giovanni Leo**
