### PR TITLE
Address ECS service-linked role creation race condition

### DIFF
--- a/beta/aws-ecs-apigateway-cfn/README.md
+++ b/beta/aws-ecs-apigateway-cfn/README.md
@@ -57,6 +57,20 @@ Consult the [Preparation Guide](/PREPARATION.md) in this repository. Since this 
 
 The console will display the stack status as `ℹ️ CREATE_IN_PROGRESS` during the deployment. The stack is expected to take a few minutes to create (~2–3 minutes when this document was written).
 
+> [!IMPORTANT]
+>
+> If this is the first time deploying an ECS cluster using your AWS account, CloudFormation may fail to create the
+> `AWS::ECS::Cluster` resource (`ECSCluster`) with an error containing:
+>
+> ```plaintext
+> Unable to assume the service linked role. Please verify that the ECS service linked role exists.
+> ```
+>
+> To resolve this issue, when the failed stack finishes rolling back (`ROLLBACK COMPLETE`), click **Delete** to remove
+> it, then try to create the stack again. The next attempt will succeed if the service-linked role has been
+> successfully created from the prior failed attempt. For more details, see the related issue:
+> https://github.com/1Password/scim-examples/issues/356.
+
 ## Step 5: Test your SCIM bridge
 
 Your **SCIM bridge URL** is displayed in the **Outputs** tab of the CloudFormation console. Click the link to access the web interface for your SCIM bridge. Sign in using your bearer token to test the connection, view status information, and download logs.

--- a/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
@@ -286,9 +286,14 @@ Resources:
             Type: SRV
       Name: scim
       NamespaceId: !Ref ServiceDiscoveryNamespace
+  ECSServiceLinkedRole:
+    Type: AWS::IAM::ServiceLinkedRole
+    Properties:
+      AWSServiceName: ecs.amazonaws.com
+      Description: Service Linked Role for ECS managed by CloudFormation
   ECSCluster:
     Type: AWS::ECS::Cluster
-    DependsOn: ExecutionRole
+    DependsOn: ECSServiceLinkedRole
     Properties:
       CapacityProviders:
         - FARGATE

--- a/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
@@ -286,14 +286,8 @@ Resources:
             Type: SRV
       Name: scim
       NamespaceId: !Ref ServiceDiscoveryNamespace
-  ECSServiceLinkedRole:
-    Type: AWS::IAM::ServiceLinkedRole
-    Properties:
-      AWSServiceName: ecs.amazonaws.com
-      Description: Service Linked Role for ECS managed by CloudFormation
   ECSCluster:
     Type: AWS::ECS::Cluster
-    DependsOn: ECSServiceLinkedRole
     Properties:
       CapacityProviders:
         - FARGATE


### PR DESCRIPTION
ECS cluster creation frequently fails for customers the first time they deploy 1Password SCIM Bridge.

This PR removes a redundant dependency that was incorrectly perceived as a fix, and introduces a callout in the accompanying CloudFormation template documentation with a suggested workaround to resolve https://github.com/1Password/scim-examples/issues/356.