### PR TITLE
Fix version bump to v2.9.11

### DIFF
--- a/aws-ecsfargate-terraform/README.md
+++ b/aws-ecsfargate-terraform/README.md
@@ -158,7 +158,7 @@ Below you can learn about some common update scenarios.
 To update your deployment to the latest version, edit the `task-definitions/scim.json` file and edit the following line:
 
 ```json
-    "image": "1password/scim:v2.9.7",
+    "image": "1password/scim:v2.9.11",
 ```
 
 Learn about the changes included in each version on the [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).

--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "op_scim_bridge",
-    "image": "1password/scim:v2.9.9",
+    "image": "1password/scim:v2.9.11",
     "cpu": 128,
     "memory": 512,
     "essential": true,

--- a/beta/aws-ecs-apigateway-cfn/README.md
+++ b/beta/aws-ecs-apigateway-cfn/README.md
@@ -97,35 +97,35 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
 
 ```json
 {
-  "build": "209031",
-  "version": "2.9.9",
+  "build": "209111",
+  "version": "2.9.11",
   "reports": [
     {
       "source": "ConfirmationWatcher",
-      "time": "2025-03-12T14:06:09Z",
-      "expires": "2025-03-12T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "RedisCache",
-      "time": "2025-03-12T14:06:09Z",
-      "expires": "2025-03-12T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "SCIMServer",
-      "time": "2025-03-12T14:06:56Z",
-      "expires": "2025-03-12T14:16:56Z",
+      "time": "2025-05-09T14:06:56Z",
+      "expires": "2025-05-09T14:16:56Z",
       "state": "healthy"
     },
     {
       "source": "StartProvisionWatcher",
-      "time": "2025-03-12T14:06:09Z",
-      "expires": "2025-03-12T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     }
   ],
-  "retrievedAt": "2025-03-12T14:06:56Z"
+  "retrievedAt": "2025-05-09T14:06:56Z"
 }
 ```
 

--- a/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
@@ -68,7 +68,7 @@ Parameters:
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: v2.9.9
+    Default: v2.9.11
     Description: >-
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
   WorkspaceCredentials:

--- a/beta/aws-ecsfargate-cfn/README.md
+++ b/beta/aws-ecsfargate-cfn/README.md
@@ -94,35 +94,35 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
 
 ```json
 {
-  "build": "209031",
-  "version": "2.9.3",
+  "build": "209111",
+  "version": "2.9.11",
   "reports": [
     {
       "source": "ConfirmationWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "RedisCache",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "SCIMServer",
-      "time": "2024-04-25T14:06:56Z",
-      "expires": "2024-04-25T14:16:56Z",
+      "time": "2025-05-09T14:06:56Z",
+      "expires": "2025-05-09T14:16:56Z",
       "state": "healthy"
     },
     {
       "source": "StartProvisionWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     }
   ],
-  "retrievedAt": "2024-04-25T14:06:56Z"
+  "retrievedAt": "2025-05-09T14:06:56Z"
 }
 ```
 

--- a/beta/google-cloud-run/README.md
+++ b/beta/google-cloud-run/README.md
@@ -108,35 +108,35 @@ Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://op-scim-bridge-exa
 
 ```json
 {
-  "build": "209031",
-  "version": "2.9.3",
+  "build": "209111",
+  "version": "2.9.11",
   "reports": [
     {
       "source": "ConfirmationWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "RedisCache",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "SCIMServer",
-      "time": "2024-04-25T14:06:56Z",
-      "expires": "2024-04-25T14:16:56Z",
+      "time": "2025-05-09T14:06:56Z",
+      "expires": "2025-05-09T14:16:56Z",
       "state": "healthy"
     },
     {
       "source": "StartProvisionWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     }
   ],
-  "retrievedAt": "2024-04-25T14:06:56Z"
+  "retrievedAt": "2025-05-09T14:06:56Z"
 }
 ```
 

--- a/do-app-platform-op-cli/README.md
+++ b/do-app-platform-op-cli/README.md
@@ -108,35 +108,35 @@ Invoke-RestMethod -Method GET -Auth OAuth -Token $(
 
 ```json
 {
-  "build": "209031",
-  "version": "2.9.3",
+  "build": "209111",
+  "version": "2.9.11",
   "reports": [
     {
       "source": "ConfirmationWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "RedisCache",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "SCIMServer",
-      "time": "2024-04-25T14:06:56Z",
-      "expires": "2024-04-25T14:16:56Z",
+      "time": "2025-05-09T14:06:56Z",
+      "expires": "2025-05-09T14:16:56Z",
       "state": "healthy"
     },
     {
       "source": "StartProvisionWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     }
   ],
-  "retrievedAt": "2024-04-25T14:06:56Z"
+  "retrievedAt": "2025-05-09T14:06:56Z"
 }
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -106,35 +106,35 @@ read`](https://developer.1password.com/docs/cli/secret-references#with-op-read):
 
 ```json
 {
-  "build": "209051",
-  "version": "2.9.5",
+  "build": "209111",
+  "version": "2.9.11",
   "reports": [
     {
       "source": "ConfirmationWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "RedisCache",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "SCIMServer",
-      "time": "2024-04-25T14:06:56Z",
-      "expires": "2024-04-25T14:16:56Z",
+      "time": "2025-05-09T14:06:56Z",
+      "expires": "2025-05-09T14:16:56Z",
       "state": "healthy"
     },
     {
       "source": "StartProvisionWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     }
   ],
-  "retrievedAt": "2024-04-25T14:06:56Z"
+  "retrievedAt": "2025-05-09T14:06:56Z"
 }
 ```
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -114,35 +114,35 @@ Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` 
 
 ```json
 {
-  "build": "209031",
-  "version": "2.9.3",
+  "build": "209111",
+  "version": "2.9.11",
   "reports": [
     {
       "source": "ConfirmationWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "RedisCache",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     },
     {
       "source": "SCIMServer",
-      "time": "2024-04-25T14:06:56Z",
-      "expires": "2024-04-25T14:16:56Z",
+      "time": "2025-05-09T14:06:56Z",
+      "expires": "2025-05-09T14:16:56Z",
       "state": "healthy"
     },
     {
       "source": "StartProvisionWatcher",
-      "time": "2024-04-25T14:06:09Z",
-      "expires": "2024-04-25T14:16:09Z",
+      "time": "2025-05-09T14:06:09Z",
+      "expires": "2025-05-09T14:16:09Z",
       "state": "healthy"
     }
   ],
-  "retrievedAt": "2024-04-25T14:06:56Z"
+  "retrievedAt": "2025-05-09T14:06:56Z"
 }
 ```
 


### PR DESCRIPTION
Most deployment examples in this repository were updated as expected in #355. This PR:

- updates the pinned 1Password SCIM Bridge image to [v2.9.11](https://releases.1password.com/provisioning/scim-bridge/#1password-scim-bridge-2.9.11) for
  - ECS with Terraform
  - ECS with CloudFormation (beta)
- updates the example health check responses throughout our documentation to match this version