### PR TITLE
fix: beta/google-cloud-run use a service account with minimal permiss…

### DIFF
--- a/beta/google-cloud-run/README.md
+++ b/beta/google-cloud-run/README.md
@@ -3,12 +3,12 @@
 _Learn how to deploy 1Password SCIM Bridge on [Cloud Run](https://cloud.google.com/run/docs/overview/what-is-cloud-run) using the Cloud Shell in Google Cloud._
 
 This guide can be used to deploy 1Password SCIM Bridge as an ingress container for a single replica [Cloud Run service](https://cloud.google.com/run/docs/overview/what-is-cloud-run#services) with the required Redis cache deployed as a sidecar container. Credentials are stored in Secret Manager and mounted as volumes attached to the SCIM bridge container.
-  
+
 The included [Cloud Run service YAML](https://cloud.google.com/run/docs/reference/yaml/v1#service) manifests are suitable for use in a production environment without modification, but are intentionally minimal for simplicity, to allow any identity provider to connect to its public endpoint, and to facilitate its use as a base for a customized deployment.
 
 ## Before you begin
 
-Complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md). You'll also need a Google Cloud account with permissions to create a project, set up billing, and enable Google Cloud APIs to create and manage secrets in Secret Manager.
+Complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREPARATION.md). You'll also need a Google Cloud account with permissions to create a project, set up billing, and enable Google Cloud APIs to create and manage secrets in Secret Manager and a service account.
 
 > [!NOTE]
 > If you don't have a Google Cloud account, you can sign up for a free trial with starting credit: <https://console.cloud.google.com/freetrial>
@@ -18,11 +18,11 @@ Complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREP
 1. Sign in to the Google Cloud console and activate Cloud Shell: <https://console.cloud.google.com?cloudshell=true>
 2. Create a [project](https://cloud.google.com/docs/overview#projects) to organize the Google Cloud resources for your 1Password SCIM Bridge deployment, and set it as the default project for your Cloud Shell environment:
 
-    ```sh
-    gcloud projects create --name "1Password SCIM Bridge" --set-as-default
-    ```
+   ```sh
+   gcloud projects create --name "1Password SCIM Bridge" --set-as-default
+   ```
 
-    Use the suggested project ID.
+   Use the suggested project ID.
 
 > [!TIP]
 > If you have already created a project for your SCIM bridge, set its ID as the default project for this Cloud Shell session. For example:
@@ -33,20 +33,22 @@ Complete the necessary [preparation steps to deploy 1Password SCIM Bridge](/PREP
 
 3. Enable the Secret Manager and Cloud Run APIs for your project:
 
-    ```sh
-    gcloud services enable secretmanager.googleapis.com run.googleapis.com
-    ```
+   ```sh
+   gcloud services enable secretmanager.googleapis.com run.googleapis.com
+   ```
 
 4. Set the default region for Cloud Run:
 
-    ```sh
-    gcloud config set run/region us-central1
-    ```
+   ```sh
+   gcloud config set run/region us-central1
+   ```
 
 > [!NOTE]
 > All region-bound resources created in the following steps will be created in the specified region. You may replace `us-central1` in the above commmand with your preferred region.
 
 ## Step 2: Create a secret for your `scimsession` credentials
+
+The scimsession file is obtained during <https://support.1password.com/scim/#step-1-set-up-and-deploy-1password-scim-bridge> <!--Needs more details about this needing "custom" configuration-->
 
 The Cloud Run service for the SCIM bridge will be configured to mount volume using a secret from Secret Manager. Follow these steps to upload your `scimsession` credentials file to the Cloud Shell, create a secret, and store the file contents as its first secret version:
 
@@ -55,9 +57,9 @@ The Cloud Run service for the SCIM bridge will be configured to mount volume usi
 3. Use the suggested destination directory. Click **Upload**. If you saved it elsewhere or used a different file name, make a note of the full path to the file.
 4. Create a secret with the contents of this file as its first secret version:
 
-    ```sh
-    gcloud secrets create scimsession --data-file=$HOME/scimsession
-    ```
+   ```sh
+   gcloud secrets create scimsession --data-file=$HOME/scimsession
+   ```
 
 > [!TIP]
 > If the file was not saved using the above suggested values, replace `$HOME/scimsession` with the actual path to the
@@ -67,15 +69,13 @@ The Cloud Run service for the SCIM bridge will be configured to mount volume usi
 > gcloud secrets create scimsession --data-file=/example/path/to/scimsession.file
 > ```
 
-5. Enable Cloud Run to access the secret using the Compute Engine default service account for the project:
+5. Enable Cloud Run to access the secret using the onepassword-provisioning service account created in <./google-workspace/README.md>:
 
-    ```sh
-    gcloud secrets add-iam-policy-binding scimsession --member=serviceAccount:$(
-      gcloud iam service-accounts list --filter="$(
-        gcloud projects describe $(gcloud config get-value project) --format='value(projectNumber)'
-      )-compute@developer.gserviceaccount.com" --format="value(email)"
-    ) --role=roles/secretmanager.secretAccessor
-    ```
+   ```sh
+   gcloud secrets add-iam-policy-binding scimsession --member=serviceAccount:$(
+     ggcloud iam service-accounts describe onepassword-provisioning --format="value(email)"
+   ) --role=roles/secretmanager.secretAccessor
+   ```
 
 ## Step 3: Deploy your SCIM bridge
 
@@ -83,7 +83,7 @@ Stream the [`op-scim-bridge.yaml`](./op-scim-bridge.yaml) Cloud Run service YAML
 
 ```sh
 curl --silent --show-error \
-  https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/op-scim-bridge.yaml |
+  https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/op-scim-bridge.yaml | sed "s/onepassword-provisioning/$(gcloud iam service-accounts describe onepassword-provisioning --format='value(email)')/g" |
   gcloud run services replace - &&
   gcloud run services add-iam-policy-binding op-scim-bridge --member=allUsers --role=roles/run.invoker &&
   gcloud run services describe op-scim-bridge --format="value(status.url)"
@@ -147,38 +147,35 @@ Similar information is presented graphically by accessing your SCIM bridge URL i
 
 ## Step 5: Connect your identity provider
 
-> [!IMPORTANT]
-> **If Google Workspace is your identity provider**, additional steps are required: [connect your 1Password SCIM Bridge to Google Workspace](./google-workspace/README.md).
+> [!IMPORTANT] > **If Google Workspace is your identity provider**, additional steps are required: [connect your 1Password SCIM Bridge to Google Workspace](./google-workspace/README.md).
 
 To finish setting up automated user provisioning, [connect your identity provider to your SCIM bridge](https://support.1password.com/scim/#step-3-connect-your-identity-provider).
 
 ## Update your SCIM bridge
 
-> [!IMPORTANT]
-> **If Google Workspace is your identity provider**, alternate steps are required: [update your SCIM bridge when Google Workspace is your IdP](./google-workspace/README.md#update-your-scim-bridge-when-google-workspace-is-your-idp)
+> [!IMPORTANT] > **If Google Workspace is your identity provider**, alternate steps are required: [update your SCIM bridge when Google Workspace is your IdP](./google-workspace/README.md#update-your-scim-bridge-when-google-workspace-is-your-idp)
 
 1. Sign in to the Google Cloud console and activate Cloud Shell: <https://console.cloud.google.com?cloudshell=true>
 
 2. Redeploy your SCIM bridge using the latest version of the Cloud Run services YAML from this directory in our repository:
 
-    ```sh
-    curl --silent --show-error \
-      https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/op-scim-bridge.yaml |
-      gcloud run services replace -
-    ```
+   ```sh
+   curl --silent --show-error \
+     https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/op-scim-bridge.yaml |
+     gcloud run services replace -
+   ```
 
 > [!TIP]
-> Check for 1Password SCIM Bridge updates on the [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).
-3. [Test your SCIM bridge deployment](#step-4-test-your-scim-bridge) using your bearer token.
+> Check for 1Password SCIM Bridge updates on the [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/). 3. [Test your SCIM bridge deployment](#step-4-test-your-scim-bridge) using your bearer token.
 
 The new version number that you updated to should appear in the health check, the container logs for 1Password SCIM Bridge, and the top left-hand side of the page if signing in to the SCIM bridge at its URL in a web browser. After you sign in to your SCIM bridge, the [Automated User Provisioning page](https://start.1password.com/integrations/provisioning/) in your 1Password account will also update with the latest access time and SCIM bridge version.
-
 
 ## Rotate credentials
 
 To use regenerated credentials in your SCIM bridge deployment, pause provisioning in your identity provider, then update the value of the `scimsession` credentials:
+
 1. Sign in to the Google Cloud console, [select the project](https://console.cloud.google.com/projectselector2/home/dashboard) for your SCIM bridge deployment, and go to the [Cloud Run](https://console.cloud.google.com/run) page.
-2. Click on your 1Password SCIM bridge Cloud Run deployment. 
+2. Click on your 1Password SCIM bridge Cloud Run deployment.
 3. Select the **Revisions** tab. Choose the latest deployed revision.
 4. Select the **Volumes** tab in the revision details pane and click the name of the secret associated with the `credentials` volume (**`scimsession`**).
 5. Add a secret version with the new SCIM bridge credentials to the secret:
@@ -187,5 +184,5 @@ To use regenerated credentials in your SCIM bridge deployment, pause provisionin
    3. Open the new `scimsession` file downloaded from 1Password in the file selector. The "Secret value" field displays the file contents that will be used for the new version.
    4. Select **Disable all past versions**.
    5. Click **Add New Version**.
-7. Return to the [Cloud Run](https://console.cloud.google.com/run) page, click the name of the Cloud Run service for your SCIM bridge deployment, and click the URL at the top to access your SCIM bridge in a new browser tab. Sign in using the new bearer token associated with the regenerated `scimsession` credentials file to verify the change.
-8. Update your identity provider configuration with your new bearer token and resume provisioning.
+6. Return to the [Cloud Run](https://console.cloud.google.com/run) page, click the name of the Cloud Run service for your SCIM bridge deployment, and click the URL at the top to access your SCIM bridge in a new browser tab. Sign in using the new bearer token associated with the regenerated `scimsession` credentials file to verify the change.
+7. Update your identity provider configuration with your new bearer token and resume provisioning.

--- a/beta/google-cloud-run/google-workspace/README.md
+++ b/beta/google-cloud-run/google-workspace/README.md
@@ -9,50 +9,42 @@ This directory includes [a template JSON file](./workspace-settings.json) used t
 > [!IMPORTANT]
 > Complete the steps to [deploy 1Password SCIM Bridge on Cloud Run](../README.md) **before** the next steps in this guide.
 
- To connect your SCIM bridge to Workspace, you'll need permissions in Google Cloud to enable the required APIs, create a service account, and an administrator with the required permissions to use the service account with your Workspace tenant.
+To connect your SCIM bridge to Workspace, you'll need permissions in Google Cloud to enable the required APIs, create a service account, and an administrator with the required permissions to use the service account with your Workspace tenant.
 
-## Step 1: Create a secret for Workspace credentials
+## Step 1: Create a service account for accessing workspace
 
 1. Sign in to the Google Cloud console and activate Cloud Shell: <https://console.cloud.google.com?cloudshell=true>
-2. Enable the Admin SDK API, create a service account named `onepassword-provisioning` and a secret named `workspace-credentials`, add a secret version from a private key for the service account, and enable Cloud Run to access it using the Compute Engine default service account for the project:
+2. Enable the Admin SDK API, create a service account named `onepassword-provisioning` and a secret named `workspace-credentials`, and enable Cloud Run to use it:
 
-    ```sh
-    gcloud services enable admin.googleapis.com &&
-      gcloud secrets create workspace-credentials &&
-      gcloud iam service-accounts keys create - --iam-account=$(
-        gcloud iam service-accounts create onepassword-provisioning --format='value(email)'
-      ) | gcloud secrets versions add workspace-credentials --data-file=- &&
-      gcloud secrets add-iam-policy-binding workspace-credentials --member=serviceAccount:$(
-        gcloud iam service-accounts list --filter="$(
-          gcloud projects describe $(gcloud config get-value project) --format='value(projectNumber)'
-        )-compute@developer.gserviceaccount.com" --format="value(email)"
-      ) --role=roles/secretmanager.secretAccessor
-    ```
+   ```sh
+   gcloud services enable admin.googleapis.com &&
+   gcloud iam service-accounts create onepassword-provisioning --format='value(email)'
+   ```
 
 3. Get the client ID of the service account:
 
-    ```sh
-    gcloud secrets versions access latest --secret=workspace-credentials | jq '.client_id' --raw-output
-    ```
+   ```sh
+   gcloud iam service-accounts describe onepassword-provisioning --format="value(uniqueId)"
+   ```
 
-    Copy the client ID returned by this command to use in the next step.
+   Copy the client ID returned by this command to use in the next step.
+
 4. In a separate browser tab or window, open the domain-wide delegation setup in the Workspace console: <https://admin.google.com/ac/owl/domainwidedelegation>. Click **Add new**, then fill out the information:
-    - **Client ID**: paste the client ID for the service account key copied to your clipboard in the previous step.
-    - **OAuth scopes**: copy and paste this comma-separated list:
 
-      ```text
-      https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.group.member.readonly, https://www.googleapis.com/auth/admin.reports.audit.readonly
-      ```
+   - **Client ID**: paste the client ID for the service account key copied to your clipboard in the previous step.
+   - **OAuth scopes**: copy and paste this comma-separated list:
+
+     ```text
+     https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.group.member.readonly, https://www.googleapis.com/auth/admin.reports.audit.readonly
+     ```
 
 ## Step 2: Download and edit the Workspace settings template
 
 1. Download the [`workspace-settings.json`](./workspace-settings.json) template file from this repository.
-2. Edit the following in this file:
-    - **Actor**: Enter the email address for a Google Workspace administrator to use with the service account.
-    - **Bridge Address**: Enter your SCIM bridge URL.
-> [!IMPORTANT]
-> This is the URL for the Cloud Run service from [Step 3: Deploy your SCIM bridge](../README.md#step-3-deploy-your-scim-bridge)
-> (_**not**_ your 1Password account sign-in address). For example: `https://op-scim-bridge-example-uc.a.run.app`.
+2. Edit the following in this file: - **Actor**: Enter the email address for a Google Workspace administrator to use with the service account. - **Bridge Address**: Enter your SCIM bridge URL.
+   > [!IMPORTANT]
+   > This is the URL for the Cloud Run service from [Step 3: Deploy your SCIM bridge](../README.md#step-3-deploy-your-scim-bridge)
+   > (_**not**_ your 1Password account sign-in address). For example: `https://op-scim-bridge-example-uc.a.run.app`.
 3. Save the file.
 
 ## Step 3: Create a secret for Workspace settings
@@ -64,9 +56,9 @@ In the Cloud Console:
 3. Use the destination directory as is (or note the path if you saved it elsewhere). Click **Upload**.
 4. Create a secret from the file:
 
-    ```sh
-    gcloud secrets create workspace-settings --data-file=$HOME/workspace-settings.json
-    ```
+   ```sh
+   gcloud secrets create workspace-settings --data-file=$HOME/workspace-settings.json
+   ```
 
 > [!TIP]
 > If the file was not saved using the suggested values, replace `$HOME/workspace-settings.json` with the actual path to
@@ -76,26 +68,24 @@ In the Cloud Console:
 > gcloud secrets create workspace-settings --data-file=/example/path/to/workspace-settings.file
 > ```
 
-5. Enable Cloud Run to access the secret using the Compute Engine default service account for the project:
+5. Enable Cloud Run to access the secret using the onepassword-provisioning service account already created:
 
-    ```sh
-    gcloud secrets add-iam-policy-binding workspace-settings --member=serviceAccount:$(
-      gcloud iam service-accounts list --filter="$(
-        gcloud projects describe $(gcloud config get-value project) --format='value(projectNumber)'
-      )-compute@developer.gserviceaccount.com" --format="value(email)"
-    ) --role=roles/secretmanager.secretAccessor
-    ```
+   ```sh
+    gcloud secrets add-iam-policy-binding scimsession --member=serviceAccount:$(
+     gcloud iam service-accounts describe onepassword-provisioning --format="value(email)"
+   ) --role=roles/secretmanager.secretAccessor
+   ```
 
 ## Step 4: Redeploy your SCIM bridge to connect to Workspace
 
 1. Use the [`op-scim-bridge-gw.yaml`](./op-scim-bridge-gw.yaml) Cloud Run YAML from this repository to create a new revision of the service that is configured to connect to Google Workspace:
 
-    ```sh
-    curl --silent --show-error \
-      https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml |
-      gcloud run services replace - &&
-      gcloud run services describe op-scim-bridge --format="value(status.url)"
-    ```
+   ```sh
+   curl --silent --show-error \
+     https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml | sed "s/onepassword-provisioning/$(gcloud iam service-accounts describe onepassword-provisioning --format='value(email)')/g" |
+     gcloud run services replace - &&
+     gcloud run services describe op-scim-bridge --format="value(status.url)"
+   ```
 
 2. Sign in to your SCIM bridge in a web browser at the HTTPS endpoint provided by Cloud Run.
 3. Select the Google group(s) you would like to assign to 1Password in the Google Workspace configuration. Click **Save**.
@@ -108,14 +98,13 @@ Learn more about automated provisioning in 1Password with Google Workspace: [Con
 
 2. Create a new revision of your SCIM bridge deployment using the latest version of the [`op-scim-bridge-gw.yaml`](./op-scim-bridge-gw.yaml) Cloud Run services YAML from this directory in our repository:
 
-    ```sh
-    curl --silent --show-error \
-      https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml |
-      gcloud run services replace -
-    ```
+   ```sh
+   curl --silent --show-error \
+     https://raw.githubusercontent.com/1Password/scim-examples/main/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml |
+     gcloud run services replace -
+   ```
 
 > [!TIP]
-> Check for 1Password SCIM Bridge updates on the [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).
-3. [Test your SCIM bridge deployment](../README.md#step-4-test-your-scim-bridge) using your bearer token.
+> Check for 1Password SCIM Bridge updates on the [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/). 3. [Test your SCIM bridge deployment](../README.md#step-4-test-your-scim-bridge) using your bearer token.
 
 The new version number that you updated to should appear in the health check, the container logs for 1Password SCIM Bridge, and the top left-hand side of the page if signing in to the SCIM bridge at its URL in a web browser. After you sign in to your SCIM bridge, the [Automated User Provisioning page](https://start.1password.com/integrations/provisioning/) in your 1Password account will also update with the latest access time and SCIM bridge version.

--- a/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml
+++ b/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml
@@ -11,6 +11,7 @@ spec:
         run.googleapis.com/cpu-throttling: "false"
         run.googleapis.com/startup-cpu-boost: "true"
     spec:
+      serviceAccountName: onepassword-provisioning # Needs to be replaced with the email of the service account created in <./google-workspace/README.md>
       containers:
         - name: scim
           image: 1password/scim:v2.9.11
@@ -29,8 +30,6 @@ spec:
           volumeMounts:
             - name: credentials
               mountPath: /home/opuser/.op
-            - name: workspace-credentials
-              mountPath: /home/opuser/.op/workspace-credentials
             - name: workspace-settings
               mountPath: /home/opuser/.op/workspace-settings
         - name: redis
@@ -50,12 +49,6 @@ spec:
             items:
               - key: latest
                 path: scimsession
-        - name: workspace-credentials
-          secret:
-            secretName: workspace-credentials
-            items:
-              - key: latest
-                path: .json
         - name: workspace-settings
           secret:
             secretName: workspace-settings

--- a/beta/google-cloud-run/op-scim-bridge.yaml
+++ b/beta/google-cloud-run/op-scim-bridge.yaml
@@ -11,6 +11,7 @@ spec:
         run.googleapis.com/cpu-throttling: "false"
         run.googleapis.com/startup-cpu-boost: "true"
     spec:
+      serviceAccountName: onepassword-provisioning # Needs to be replaced with the email of the service account created in <./google-workspace/README.md>
       containers:
         - name: scim
           image: 1password/scim:v2.9.11


### PR DESCRIPTION
…ions

Google recommend not using this service account as it's has more permissions than are typically required [[1]](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)

This PR updates the cloud run setup to use a dedicated service account, and then only grant the required permissions to it instead.