### PR TITLE
Added Redis Dependency for SCIM and Redis Healthcheck in Cloud Run

### DIFF
--- a/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml
+++ b/beta/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml
@@ -10,6 +10,7 @@ spec:
         autoscaling.knative.dev/maxScale: "1"
         run.googleapis.com/cpu-throttling: "false"
         run.googleapis.com/startup-cpu-boost: "true"
+        run.googleapis.com/container-dependencies: '{"scim":["redis"]}'
     spec:
       containers:
         - name: scim
@@ -39,6 +40,13 @@ spec:
             - --maxmemory 256mb
             - --maxmemory-policy volatile-lru
             - --save ""
+          startupProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 500m

--- a/beta/google-cloud-run/op-scim-bridge.yaml
+++ b/beta/google-cloud-run/op-scim-bridge.yaml
@@ -10,6 +10,7 @@ spec:
         autoscaling.knative.dev/maxScale: "1"
         run.googleapis.com/cpu-throttling: "false"
         run.googleapis.com/startup-cpu-boost: "true"
+        run.googleapis.com/container-dependencies: '{"scim":["redis"]}'
     spec:
       containers:
         - name: scim
@@ -30,6 +31,13 @@ spec:
             - --maxmemory 256mb
             - --maxmemory-policy volatile-lru
             - --save ""
+          startupProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
# Pull Request Description

This PR updates the `op-scim-bridge.yaml` and `op-scim-bridge-gw.yaml` configurations for the **Cloud Run 1Password SCIM bridge** to address timing issues where the `scim` container attempts to connect to `redis` before it is fully operational.

## Changes

- Added `run.googleapis.com/container-dependencies` annotation to both `op-scim-bridge.yaml` and `op-scim-bridge-gw.yaml` to ensure the `scim` container starts only after the `redis` container is ready.
- Added a `startupProbe` (TCP check on port `6379`, `5s` initial delay, `10s` period, `3` failure threshold, `1s` timeout) to the `redis` container in both YAMLs to confirm Redis readiness.