### PR TITLE
fix: drop invalid header fields of aws alb

### DIFF
--- a/aws-ecsfargate-terraform/main.tf
+++ b/aws-ecsfargate-terraform/main.tf
@@ -199,10 +199,11 @@ resource "aws_ecs_service" "op_scim_bridge" {
 }
 
 resource "aws_alb" "op_scim_bridge" {
-  name               = var.name_prefix == "" ? "op-scim-bridge-alb" : format("%s-%s", local.name_prefix, "alb")
-  load_balancer_type = "application"
-  subnets            = data.aws_subnets.public.ids
-  security_groups    = [aws_security_group.alb.id]
+  name                       = var.name_prefix == "" ? "op-scim-bridge-alb" : format("%s-%s", local.name_prefix, "alb")
+  load_balancer_type         = "application"
+  subnets                    = data.aws_subnets.public.ids
+  security_groups            = [aws_security_group.alb.id]
+  drop_invalid_header_fields = true
 
   tags = local.tags
 }


### PR DESCRIPTION
By default is more secure to drop the invalid header fields especially since this is exposed on the internet.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#drop_invalid_header_fields-1