### PR TITLE
Update Redis health check for SCIM startup on Cloud Run and update bridge version to 2.9.13

### DIFF
--- a/aws-ecsfargate-terraform/README.md
+++ b/aws-ecsfargate-terraform/README.md
@@ -158,7 +158,7 @@ Below you can learn about some common update scenarios.
 To update your deployment to the latest version, edit the `task-definitions/scim.json` file and edit the following line:
 
 ```json
-    "image": "1password/scim:v2.9.12",
+    "image": "1password/scim:v2.9.13",
 ```
 
 Learn about the changes included in each version on the [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).

--- a/aws-ecsfargate-terraform/task-definitions/scim.json
+++ b/aws-ecsfargate-terraform/task-definitions/scim.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "op_scim_bridge",
-    "image": "1password/scim:v2.9.12",
+    "image": "1password/scim:v2.9.13",
     "cpu": 128,
     "memory": 512,
     "essential": true,

--- a/azure-container-apps-arm/README.md
+++ b/azure-container-apps-arm/README.md
@@ -65,7 +65,7 @@ To finish setting up automated user provisioning, [connect your identity provide
 1. Within your deployed 1Password SCIM Bridge Container App in the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
 2. Click **Edit and deploy**.
 3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
-4. Change the version number **2.9.12** in the **Image and Tag** field, **1password/scim:v2.9.12** to match the latest version from our [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).
+4. Change the version number **2.9.13** in the **Image and Tag** field, **1password/scim:v2.9.13** to match the latest version from our [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).
 5. Select **Save**.
 6. Select **Create** to deploy a new revision using the updated image.
 7. Enter your SCIM bridge URL in a browser and sign in with your bearer token.

--- a/azure-container-apps-arm/aca-op-scim-bridge-template.json
+++ b/azure-container-apps-arm/aca-op-scim-bridge-template.json
@@ -142,7 +142,7 @@
                 "template": {
                     "containers": [
                         {
-                            "image": "docker.io/1password/scim:v2.9.12",
+                            "image": "docker.io/1password/scim:v2.9.13",
                             "name": "op-scim-bridge",
                             "resources": {
                                 "cpu": "[variables('resourceSettings')[parameters('provisioningVolume')].cpu]",

--- a/azure-container-apps/README.md
+++ b/azure-container-apps/README.md
@@ -63,7 +63,7 @@ After the deployment is complete, click **Go to resource**, then continue to ste
 4. Adjust the following:
    - **Name**: Enter `op-scim-bridge`.
    - **Image source**: Choose **Docker Hub or other registries**.
-   - **Image and tag**: Enter `1password/scim:v2.9.12`.
+   - **Image and tag**: Enter `1password/scim:v2.9.13`.
    - **CPU cores**: Enter `0.25`
    - **Memory (Gi)**: Enter `0.5`.
 5. Choose **Volume mounts** tab at the top of the 'Add a container' blade.
@@ -157,7 +157,7 @@ To connect Google Workspace using the Azure Cloud Shell or AZ CLI, follow the st
 1. Within your deployed 1Password SCIM Bridge Container App in the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
 2. Click **Edit and deploy**.
 3. Select the checkbox next to your **op-scim-bridge** container, then choose **Edit**.
-4. Change the version number **2.9.12** in the **Image and Tag** field, **1password/scim:v2.9.12** to match the latest version from our [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).
+4. Change the version number **2.9.13** in the **Image and Tag** field, **1password/scim:v2.9.13** to match the latest version from our [SCIM bridge releases notes website](https://releases.1password.com/provisioning/scim-bridge/).
 5. Select **Save**.
 6. Select **Create** to deploy a new revision using the updated image.
 7. Enter your SCIM bridge URL in a browser and sign in with your bearer token.

--- a/azure-container-apps/aca-op-scim-bridge.yaml
+++ b/azure-container-apps/aca-op-scim-bridge.yaml
@@ -15,7 +15,7 @@ properties:
       transport: Auto
   template:
     containers:
-      - image: docker.io/1password/scim:v2.9.12
+      - image: docker.io/1password/scim:v2.9.13
         name: op-scim-bridge
         volumeMounts:
           - mountPath: "/home/opuser/.op"

--- a/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml
+++ b/azure-container-apps/google-workspace/aca-gw-op-scim-bridge.yaml
@@ -15,7 +15,7 @@ properties:
       transport: Auto
   template:
     containers:
-      - image: docker.io/1password/scim:v2.9.12
+      - image: docker.io/1password/scim:v2.9.13
         name: op-scim-bridge
         volumeMounts:
           - mountPath: "/home/opuser/.op"

--- a/beta/aws-ecs-apigateway-cfn/README.md
+++ b/beta/aws-ecs-apigateway-cfn/README.md
@@ -97,8 +97,8 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
 
 ```json
 {
-  "build": "209121",
-  "version": "2.9.12",
+  "build": "209131",
+  "version": "2.9.13",
   "reports": [
     {
       "source": "ConfirmationWatcher",

--- a/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecs-apigateway-cfn/op-scim-bridge.yaml
@@ -68,7 +68,7 @@ Parameters:
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: v2.9.12
+    Default: v2.9.13
     Description: >-
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
   WorkspaceCredentials:

--- a/beta/aws-ecsfargate-cfn/README.md
+++ b/beta/aws-ecsfargate-cfn/README.md
@@ -94,8 +94,8 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
 
 ```json
 {
-  "build": "209121",
-  "version": "2.9.12",
+  "build": "209131",
+  "version": "2.9.13",
   "reports": [
     {
       "source": "ConfirmationWatcher",

--- a/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
+++ b/beta/aws-ecsfargate-cfn/op-scim-bridge.yaml
@@ -85,7 +85,7 @@ Parameters:
     NoEcho: true
   SCIMBridgeVersion:
     Type: String
-    Default: v2.9.12
+    Default: v2.9.13
     Description: >-
       The tag of the 1Password SCIM Bridge image to pull from Docker Hub.
   WorkspaceCredentials:

--- a/beta/kustomize/README.md
+++ b/beta/kustomize/README.md
@@ -102,10 +102,10 @@ To finish setting up automated user provisioning, [connect your identity provide
 
 👍 Check for 1Password SCIM Bridge updates on the [SCIM bridge release page](https://app-updates.agilebits.com/product_history/SCIM).
 
-To update the SCIM bridge, connect to your Kubernetes cluster and run the following command, replacing v2.9.12 with the latest version:
+To update the SCIM bridge, connect to your Kubernetes cluster and run the following command, replacing v2.9.13 with the latest version:
 
 ```bash
-kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.9.12 -n=op-scim
+kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.9.13 -n=op-scim
 ```
 
 The update should take 2-3 minutes for Kubernetes to complete.

--- a/beta/kustomize/base/op-scim-deployment.yaml
+++ b/beta/kustomize/base/op-scim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: op-scim-bridge
-          image: 1password/scim:v2.9.12
+          image: 1password/scim:v2.9.13
           ports:
             # HTTPS port (external TCP traffic should be forwarded to this port by default)
             - name: https

--- a/do-app-platform-op-cli/README.md
+++ b/do-app-platform-op-cli/README.md
@@ -108,8 +108,8 @@ Invoke-RestMethod -Method GET -Auth OAuth -Token $(
 
 ```json
 {
-  "build": "209121",
-  "version": "2.9.12",
+  "build": "209131",
+  "version": "2.9.13",
   "reports": [
     {
       "source": "ConfirmationWatcher",

--- a/do-app-platform-op-cli/google-workspace/op-scim-bridge-gw.yaml
+++ b/do-app-platform-op-cli/google-workspace/op-scim-bridge-gw.yaml
@@ -40,7 +40,7 @@ services:
       registry: 1password
       registry_type: DOCKER_HUB
       repository: scim
-      tag: v2.9.12
+      tag: v2.9.13
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
     name: op-scim-bridge

--- a/do-app-platform-op-cli/op-scim-bridge.yaml
+++ b/do-app-platform-op-cli/op-scim-bridge.yaml
@@ -32,7 +32,7 @@ services:
       registry: 1password
       registry_type: DOCKER_HUB
       repository: scim
-      tag: v2.9.12
+      tag: v2.9.13
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
     name: op-scim-bridge

--- a/docker/README.md
+++ b/docker/README.md
@@ -106,8 +106,8 @@ read`](https://developer.1password.com/docs/cli/secret-references#with-op-read):
 
 ```json
 {
-  "build": "209121",
-  "version": "2.9.12",
+  "build": "209131",
+  "version": "2.9.13",
   "reports": [
     {
       "source": "ConfirmationWatcher",
@@ -156,7 +156,7 @@ Quarterly review and maintenance is recommended to update the operating system, 
 To use a new version of SCIM bridge, update the `op-scim-bridge_scim` service with the new image tag from the [`1password/scim` repository on Docker Hub](https://hub.docker.com/r/1password/scim/tags):
 
 ```sh
-docker service update op-scim-bridge_scim --image 1password/scim:v2.9.12
+docker service update op-scim-bridge_scim --image 1password/scim:v2.9.13
 ```
 
 Your SCIM bridge should automatically reboot using the specified version, typically in a few seconds.

--- a/docker/compose.template.yaml
+++ b/docker/compose.template.yaml
@@ -22,7 +22,7 @@ services:
           memory: 512M
     env_file: ./scim.env
     environment: [OP_REDIS_URL=redis://redis:6379]
-    image: 1password/scim:v2.9.12
+    image: 1password/scim:v2.9.13
     networks: [op-scim]
     ports: [443:8443]
     secrets:

--- a/google-cloud-run/README.md
+++ b/google-cloud-run/README.md
@@ -108,8 +108,8 @@ Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://op-scim-bridge-exa
 
 ```json
 {
-  "build": "209121",
-  "version": "2.9.12",
+  "build": "209131",
+  "version": "2.9.13",
   "reports": [
     {
       "source": "ConfirmationWatcher",

--- a/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml
+++ b/google-cloud-run/google-workspace/op-scim-bridge-gw.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: scim
-          image: 1password/scim:v2.9.12
+          image: 1password/scim:v2.9.13
           ports:
             - name: http1
               containerPort: 3002
@@ -44,9 +44,9 @@ spec:
             tcpSocket:
               port: 6379
             initialDelaySeconds: 5
-            periodSeconds: 10
-            failureThreshold: 3
-            timeoutSeconds: 1
+            periodSeconds: 20
+            failureThreshold: 5
+            timeoutSeconds: 2
           resources:
             limits:
               cpu: 500m

--- a/google-cloud-run/op-scim-bridge.yaml
+++ b/google-cloud-run/op-scim-bridge.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: scim
-          image: 1password/scim:v2.9.12
+          image: 1password/scim:v2.9.13
           ports:
             - name: http1
               containerPort: 3002
@@ -35,9 +35,9 @@ spec:
             tcpSocket:
               port: 6379
             initialDelaySeconds: 5
-            periodSeconds: 10
-            failureThreshold: 3
-            timeoutSeconds: 1
+            periodSeconds: 20
+            failureThreshold: 5
+            timeoutSeconds: 2
           resources:
             limits:
               cpu: 500m

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -114,8 +114,8 @@ Replace `mF_9.B5f-4.1JqM` with your bearer token and `https://scim.example.com` 
 
 ```json
 {
-  "build": "209121",
-  "version": "2.9.12",
+  "build": "209131",
+  "version": "2.9.13",
   "reports": [
     {
       "source": "ConfirmationWatcher",
@@ -160,7 +160,7 @@ To finish setting up automated user provisioning, [connect your identity provide
 To update SCIM bridge, connect to your Kubernetes cluster and run the following command:
 
 ```sh
-kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.9.12
+kubectl set image deploy/op-scim-bridge op-scim-bridge=1password/scim:v2.9.13
 ```
 
 > **Note**

--- a/kubernetes/op-scim-deployment.yaml
+++ b/kubernetes/op-scim-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 999
       containers:
         - name: op-scim-bridge
-          image: 1password/scim:v2.9.12
+          image: 1password/scim:v2.9.13
           securityContext:
             allowPrivilegeEscalation: false
           ports:


### PR DESCRIPTION
## Description

This PR addresses an issue where the SCIM service might start before Redis is fully active on Google Cloud Run, leading to startup failures. This PR updates the health check mechanism to verify Redis readiness before proceeding.

Additionally, it updates the SCIM bridge version from 2.9.12 to 2.9.13 across all example configurations and related files.

## Changes Made
- Updated Redis health check in the startup script for SCIM on Cloud Run.
- Replaced all occurrences of version `2.9.12` with `2.9.13` in configuration files, documentation, and examples.
