### PR TITLE
Update op-scim-bridge.yaml

### DIFF
--- a/google-cloud-run/op-scim-bridge.yaml
+++ b/google-cloud-run/op-scim-bridge.yaml
@@ -12,6 +12,9 @@ spec:
         run.googleapis.com/startup-cpu-boost: "true"
         run.googleapis.com/container-dependencies: '{"scim":["redis"]}'
     spec:
+      # 🔧 This value will be dynamically replaced during deployment using envsubst
+      serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+
       containers:
         - name: scim
           image: 1password/scim:v2.9.13


### PR DESCRIPTION
Using default service account is against security policies. So, it is better to use a custom service account. The modification was done in order to create a generic repo others can use by giving them the opportunity to input their custom service account with validation check. I did also create custom script that can allow user to deploy this, while inputting their custom service account. - How to Use This YAML You can deploy it using a script like this:

#!/bin/bash

# Usage: ./deploy-scim.sh YOUR-SERVICE-ACCOUNT@YOUR-PROJECT-ID.iam.gserviceaccount.com

SERVICE_ACCOUNT="$1"

if [ -z "$SERVICE_ACCOUNT" ]; then
  echo "❌ Please provide a service account email."
  exit 1
fi

curl --silent --show-error \
  https://raw.githubusercontent.com/YOUR_GITHUB_USERNAME/YOUR_NEW_REPO/main/op-scim-bridge-custom.yaml |
  SERVICE_ACCOUNT_NAME="$SERVICE_ACCOUNT" envsubst |
  gcloud run services replace - --region=us-central1 &&

gcloud run services add-iam-policy-binding op-scim-bridge \
  --member=allUsers \
  --role=roles/run.invoker \
  --region=us-central1 &&

gcloud run services describe op-scim-bridge \
  --region=us-central1 \
  --format="value(status.url)"