### PR TITLE
Fix broken Redis image for DigitalOcean App Platform example

### DIFF
--- a/do-app-platform-op-cli/google-workspace/op-scim-bridge-gw.yaml
+++ b/do-app-platform-op-cli/google-workspace/op-scim-bridge-gw.yaml
@@ -1,22 +1,15 @@
 name: op-scim-bridge
 services:
-  - envs:
-      - key: ALLOW_EMPTY_PASSWORD
-        scope: RUN_AND_BUILD_TIME
-        value: "yes"
-      - key: REDIS_ARGS
-        scope: RUN_AND_BUILD_TIME
-        value: "--maxmemory 256mb --maxmemory-policy volatile-lru"
-    image:
-      registry: bitnami
+  - image:
+      registry: library
       registry_type: DOCKER_HUB
       repository: redis
-      tag: latest
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
     internal_ports:
       - 6379
     name: op-scim-redis
+    run_command: redis-server --maxmemory 256mb --maxmemory-policy volatile-lru --save ""
   - envs:
       - key: OP_REDIS_URL
         scope: RUN_AND_BUILD_TIME

--- a/do-app-platform-op-cli/op-scim-bridge.yaml
+++ b/do-app-platform-op-cli/op-scim-bridge.yaml
@@ -1,22 +1,15 @@
 name: op-scim-bridge
 services:
-  - envs:
-      - key: ALLOW_EMPTY_PASSWORD
-        scope: RUN_AND_BUILD_TIME
-        value: "yes"
-      - key: REDIS_ARGS
-        scope: RUN_AND_BUILD_TIME
-        value: "--maxmemory 256mb --maxmemory-policy volatile-lru"
-    image:
-      registry: bitnami
+  - image:
+      registry: library
       registry_type: DOCKER_HUB
       repository: redis
-      tag: latest
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
     internal_ports:
       - 6379
     name: op-scim-redis
+    run_command: redis-server --maxmemory 256mb --maxmemory-policy volatile-lru --save ""
   - envs:
       - key: OP_REDIS_URL
         scope: RUN_AND_BUILD_TIME


### PR DESCRIPTION
Our deployment example for DigitalOcean App Platform uses the Bitnami Redis container image in its app spec. This image and its repository are no longer available on Docker Hub as part of planned changes to Bitnami's catalog (see https://github.com/bitnami/containers/issues/83267).

1Password SCIM Bridge does not require any specific Redis distribution, and all other deployment examples do not specify a repository and use the Docker Official "library" Redis image (https://hub.docker.com/_/redis).

In this PR, we

- switch to the Docker Official Redis image on Docker Hub
- move Redis configuration from environment variables to container run command to align with other deployment examples and produce slightly cleaner logs
- remove redundant env var config specific to Bitnami
- include the missing `save ""` configuration directive to disable redundant paging to disk
- carry out same changes in Google Workspace app spec file
