### PR TITLE
Update ARM template to use Azure Monitor logging for Container Apps environment

### DIFF
--- a/azure-container-apps-arm/aca-op-scim-bridge-template.json
+++ b/azure-container-apps-arm/aca-op-scim-bridge-template.json
@@ -97,13 +97,27 @@
             },
             "properties": {
                 "appLogsConfiguration": {
-                    "destination": "log-analytics",
-                    "logAnalyticsConfiguration": {
-                        "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))).customerId]",
-                        "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]"
-                    }
+                    "destination": "azure-monitor"
                 },
                 "zoneRedundant": false
+            }
+        },
+        {
+            "type": "Microsoft.App/managedEnvironments/providers/diagnosticSettings",
+            "apiVersion": "2021-05-01-preview",
+            "name": "[concat(parameters('containerAppEnvName'), '/Microsoft.Insights/ContainerAppLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppEnvName'))]",
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+            ],
+            "properties": {
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]",
+                "logs": [
+                    {
+                        "categoryGroup": "allLogs",
+                        "enabled": true
+                    }
+                ]
             }
         },
         {


### PR DESCRIPTION
This PR updates the Azure Resource Manager (ARM) template for the 1Password SCIM Bridge deployment to adopt the recommended Azure Monitor logging configuration in place of the legacy direct Log Analytics integration.

Key changes:
- Modified the `appLogsConfiguration` in the managed environment to set `destination` to "azure-monitor".
- Added a new diagnostic settings resource to route all logs to the existing Log Analytics workspace.

This addresses the eventual deprecation of the old logging method and ensures future logs use standard tables without the _CL suffix. Existing _CL tables and historical data remain unaffected. Tested the deployment to confirm logs are ingested correctly into the new tables. No breaking changes to the application or other resources.